### PR TITLE
fix(string-decode): add decoding support for ISO 8859-1

### DIFF
--- a/lib/bacnet-asn1.js
+++ b/lib/bacnet-asn1.js
@@ -900,8 +900,10 @@ var multi_charset_characterstring_decode = function(buffer, offset, maxLength, e
         return;
       }
       break;
-    case baEnum.BacnetCharacterStringEncodings.CHARACTER_UCS4:
     case baEnum.BacnetCharacterStringEncodings.CHARACTER_ISO8859:
+      nodeEncoding = 'latin1';
+      break;
+    case baEnum.BacnetCharacterStringEncodings.CHARACTER_UCS4:
     case baEnum.BacnetCharacterStringEncodings.CHARACTER_MS_DBCS:
     case baEnum.BacnetCharacterStringEncodings.CHARACTER_JISX_0208:
       return;


### PR DESCRIPTION
ISO 8859-1 is also known as Latin-1

We need this for the old Desigo PX controllers!