### PR TITLE
chore(codeclimate): disable duplication engine due to false-positives

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,11 @@
+engines:
+  eslint:
+    enabled: true
+  fixme:
+    enabled: true
+  markdownlint:
+    enabled: true
+  duplication:
+    enabled: false
+exclude_paths:
+- "CHANGELOG.md"


### PR DESCRIPTION
The duplication engine creates many false-positive findings due to the nature of BACNETs use of enumerations in a lot of places.