### PR TITLE
Use decodeCOVNotify

### DIFF
--- a/lib/bacnet-client.js
+++ b/lib/bacnet-client.js
@@ -175,9 +175,9 @@ module.exports = function(options) {
       if (!result) return debug('Received invalid writePropertyMultiple message');
       self.emit('writePropertyMultiple', {address: address, invokeId: invokeId, request: result});
     } else if (service === baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_COV_NOTIFICATION) {
-      result = baServices.decodeCOVNotifyUnconfirmed(buffer, offset, length);
-      if (!result) return debug('Received invalid covNotifyUnconfirmed message');
-      self.emit('covNotifyUnconfirmed', {address: address, invokeId: invokeId, request: result});
+      result = baServices.decodeCOVNotify(buffer, offset, length);
+      if (!result) return debug('Received invalid covNotify message');
+      self.emit('covNotify', {address: address, invokeId: invokeId, request: result});
     } else if (service === baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_ATOMIC_WRITE_FILE) {
       result = baServices.decodeAtomicWriteFile(buffer, offset, length);
       if (!result) return debug('Received invalid atomicWriteFile message');
@@ -256,10 +256,9 @@ module.exports = function(options) {
       if (!result) return debug('Received invalid WhoHas message');
       self.emit('whoHas', {address: address, lowLimit: result.lowLimit, highLimit: result.highLimit, objId: result.objId, objName: result.objName});
     } else if (service === baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_COV_NOTIFICATION) {
-      debug('TODO: Implement COVNotify');
-      //result = baServices.decodeCOVNotifyUnconfirmed(buffer, offset, length);
-      //if (!result) return debug('Received invalid COVNotify message');
-      //self.emit('covNotify', address, result.subscriberProcessIdentifier, result.initiatingDeviceIdentifier, result.monitoredObjectIdentifier, result.timeRemaining, result.values);
+      result = baServices.decodeCOVNotify(buffer, offset, length);
+      if (!result) return debug('Received invalid covNotifyUnconfirmed message');
+      self.emit('covNotifyUnconfirmed', {address: address, request: result});
     } else if (service === baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION) {
       result = baServices.decodeTimeSync(buffer, offset, length);
       if (!result) return debug('Received invalid TimeSync message');


### PR DESCRIPTION
Closes https://github.com/fh1ch/node-bacstack/issues/69

This PR uses changes the non existing `decodeCOVNotifyUnconfirmed` to `decodeCOVNotify` and emits corresponding events.