### PR TITLE
fix(bacnet-node-type): correct enum according to BACnet spec

### DIFF
--- a/lib/bacnet-enum.js
+++ b/lib/bacnet-enum.js
@@ -1150,18 +1150,18 @@ module.exports.BacnetPropertyIds = {
 };
 
 module.exports.BacnetNodeTypes = {
-  NT_UNKNOWN: 1,
-  NT_SYSTEM: 2,
-  NT_NETWORK: 3,
-  NT_DEVICE: 4,
-  NT_ORGANIZATIONAL: 5,
-  NT_AREA: 6,
-  NT_EQUIPMENT: 7,
-  NT_POINT: 8,
-  NT_COLLECTION: 9,
-  NT_PROPERTY: 10,
-  NT_FUNCTIONAL: 11,
-  NT_OTHER: 12
+  NT_UNKNOWN: 0,
+  NT_SYSTEM: 1,
+  NT_NETWORK: 2,
+  NT_DEVICE: 3,
+  NT_ORGANIZATIONAL: 4,
+  NT_AREA: 5,
+  NT_EQUIPMENT: 6,
+  NT_POINT: 7,
+  NT_COLLECTION: 8,
+  NT_PROPERTY: 9,
+  NT_FUNCTIONAL: 10,
+  NT_OTHER: 11
 };
 
 module.exports.BacnetBvlcFunctions = {


### PR DESCRIPTION
Seems this enum is not used, but I need it in another project and discovered that it was not according the spec...

```
[Add new BACnetNodeType enumeration to Clause 21, page 419]
BACnetNodeType ::= ENUMERATED {
 unknown (0),
 system (1),
 network (2),
 device (3),
 organizational (4),
 area (5),
 equipment (6),
 point (7),
 collection (8), 
ANSI/ASHRAE Addendum d to ANSI/ASHRAE Standard 135-2004 5
 property (9),
 functional (10),
 other (11)
}
```
 