### PR TITLE
refactor: rework and align naming of various API parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ client.whoIs();
 
 // Read Device Object
 var requestArray = [{
-  objectIdentifier: {type: 8, instance: 4194303},
-  propertyReferences: [{propertyIdentifier: 8}]
+  objectId: {type: 8, instance: 4194303},
+  properties: [{id: 8}]
 }];
 client.readPropertyMultiple('192.168.1.43', requestArray, function(err, value) {
   console.log('value: ', value);

--- a/lib/bacnet-asn1.js
+++ b/lib/bacnet-asn1.js
@@ -387,12 +387,12 @@ var encodeClosingTag = module.exports.encodeClosingTag = function(buffer, tagNum
 };
 
 var encodeReadAccessSpecification = module.exports.encodeReadAccessSpecification = function(buffer, value) {
-  encodeContextObjectId(buffer, 0, value.objectIdentifier.type, value.objectIdentifier.instance);
+  encodeContextObjectId(buffer, 0, value.objectId.type, value.objectId.instance);
   encodeOpeningTag(buffer, 1);
-  value.propertyReferences.forEach(function(p) {
-    encodeContextEnumerated(buffer, 0, p.propertyIdentifier);
-    if (p.propertyArrayIndex && p.propertyArrayIndex !== BACNET_ARRAY_ALL) {
-      encodeContextUnsigned(buffer, 1, p.propertyArrayIndex);
+  value.properties.forEach(function(p) {
+    encodeContextEnumerated(buffer, 0, p.id);
+    if (p.index && p.index !== BACNET_ARRAY_ALL) {
+      encodeContextUnsigned(buffer, 1, p.index);
     }
   });
   encodeClosingTag(buffer, 1);
@@ -408,27 +408,27 @@ var encodeCovSubscription = function(buffer, value) {
   encodeOpeningTag(buffer, 0);
   encodeOpeningTag(buffer, 0);
   encodeOpeningTag(buffer, 1);
-  encodeApplicationUnsigned(buffer, value.Recipient.net);
-  if (value.Recipient.net === 0xFFFF) {
+  encodeApplicationUnsigned(buffer, value.recipient.network);
+  if (value.recipient.network === 0xFFFF) {
     encodeApplicationOctetString(buffer, 0, 0, 0);
   } else {
-    encodeApplicationOctetString(buffer, value.Recipient.adr, 0, value.Recipient.adr.length);
+    encodeApplicationOctetString(buffer, value.recipient.address, 0, value.recipient.address.length);
   }
   encodeClosingTag(buffer, 1);
   encodeClosingTag(buffer, 0);
-  encodeContextUnsigned(buffer, 1, value.subscriptionProcessIdentifier);
+  encodeContextUnsigned(buffer, 1, value.subscriptionProcessId);
   encodeClosingTag(buffer, 0);
   encodeOpeningTag(buffer, 1);
-  encodeContextObjectId(buffer, 0, value.monitoredObjectIdentifier.type, value.monitoredObjectIdentifier.instance);
-  encodeContextEnumerated(buffer, 1, value.monitoredProperty.propertyIdentifier);
-  if (value.monitoredProperty.propertyArrayIndex !== BACNET_ARRAY_ALL) {
-    encodeContextUnsigned(buffer, 2, value.monitoredProperty.propertyArrayIndex);
+  encodeContextObjectId(buffer, 0, value.monitoredObjectId.type, value.monitoredObjectId.instance);
+  encodeContextEnumerated(buffer, 1, value.monitoredProperty.id);
+  if (value.monitoredProperty.index !== BACNET_ARRAY_ALL) {
+    encodeContextUnsigned(buffer, 2, value.monitoredProperty.index);
   }
   encodeClosingTag(buffer, 1);
-  encodeContextBoolean(buffer, 2, value.IssueConfirmedNotifications);
-  encodeContextUnsigned(buffer, 3, value.TimeRemaining);
-  if (value.COVIncrement > 0) {
-    encodeContextReal(buffer, 4, value.COVIncrement);
+  encodeContextBoolean(buffer, 2, value.issueConfirmedNotifications);
+  encodeContextUnsigned(buffer, 3, value.timeRemaining);
+  if (value.covIncrement > 0) {
+    encodeContextReal(buffer, 4, value.covIncrement);
   }
 };
 
@@ -497,8 +497,8 @@ var bacappEncodeApplicationData = module.exports.bacappEncodeApplicationData = f
 };
 
 var bacappEncodeDeviceObjPropertyRef = function(buffer, value) {
-  encodeContextObjectId(buffer, 0, value.objectIdentifier.type, value.objectIdentifier.instance);
-  encodeContextEnumerated(buffer, 1, value.propertyIdentifier);
+  encodeContextObjectId(buffer, 0, value.objectId.type, value.objectId.instance);
+  encodeContextEnumerated(buffer, 1, value.id);
   if (value.arrayIndex !== BACNET_ARRAY_ALL) {
     encodeContextUnsigned(buffer, 2, value.arrayIndex);
   }
@@ -703,12 +703,12 @@ var bacappDecodeApplicationData = module.exports.bacappDecodeApplicationData = f
 };
 
 var encodeReadAccessResult = module.exports.encodeReadAccessResult = function(buffer, value) {
-  encodeContextObjectId(buffer, 0, value.objectIdentifier.type, value.objectIdentifier.instance);
+  encodeContextObjectId(buffer, 0, value.objectId.type, value.objectId.instance);
   encodeOpeningTag(buffer, 1);
   value.values.forEach(function(item) {
-    encodeContextEnumerated(buffer, 2, item.property.propertyIdentifier);
-    if (item.property.propertyArrayIndex !== BACNET_ARRAY_ALL) {
-      encodeContextUnsigned(buffer, 3, item.property.propertyArrayIndex);
+    encodeContextEnumerated(buffer, 2, item.property.id);
+    if (item.property.index !== BACNET_ARRAY_ALL) {
+      encodeContextUnsigned(buffer, 3, item.property.index);
     }
     if (item.value && item.value[0] && item.value[0].value && item.value[0].value.type === 'BacnetError') {
       encodeOpeningTag(buffer, 5);
@@ -732,7 +732,7 @@ var decodeReadAccessResult = module.exports.decodeReadAccessResult = function(bu
   if (!decodeIsContextTag(buffer, offset + len, 0)) return;
   len++;
   var result = decodeObjectId(buffer, offset + len);
-  value.objectIdentifier = {
+  value.objectId = {
     type: result.objectType,
     instance: result.instance
   };
@@ -740,7 +740,7 @@ var decodeReadAccessResult = module.exports.decodeReadAccessResult = function(bu
   if (!decodeIsOpeningTagNumber(buffer, offset + len, 1)) return -1;
   len++;
 
-  var valueList = [];
+  var values = [];
   while ((apduLen - len) > 0) {
     var newEntry = {};
     if (decodeIsClosingTagNumber(buffer, offset + len, 1)) {
@@ -751,24 +751,24 @@ var decodeReadAccessResult = module.exports.decodeReadAccessResult = function(bu
     len += result.len;
     if (result.tagNumber !== 2) return;
     result = decodeEnumerated(buffer, offset + len, result.value);
-    newEntry.propertyIdentifier = result.value;
+    newEntry.id = result.value;
     len += result.len;
 
     result = decodeTagNumberAndValue(buffer, offset + len);
     if (result.tagNumber === 3) {
       len += result.len;
       result = decodeUnsigned(buffer, offset + len, result.value);
-      newEntry.propertyArrayIndex = result.value;
+      newEntry.index = result.value;
       len += result.len;
     } else {
-      newEntry.propertyArrayIndex = BACNET_ARRAY_ALL;
+      newEntry.index = BACNET_ARRAY_ALL;
     }
     result = decodeTagNumberAndValue(buffer, offset + len);
     len += result.len;
     if (result.tagNumber === 4) {
       var localValues = [];
       while ((len + offset) <= buffer.length && !decodeIsClosingTagNumber(buffer, offset + len, 4)) {
-        var localResult = bacappDecodeApplicationData(buffer, offset + len, apduLen + offset - 1, value.objectIdentifier.type, newEntry.propertyIdentifier);
+        var localResult = bacappDecodeApplicationData(buffer, offset + len, apduLen + offset - 1, value.objectId.type, newEntry.id);
         if (!localResult) return;
         len += localResult.len;
         var resObj = {
@@ -810,9 +810,9 @@ var decodeReadAccessResult = module.exports.decodeReadAccessResult = function(bu
         value: err
       };
     }
-    valueList.push(newEntry);
+    values.push(newEntry);
   }
-  value.values = valueList;
+  value.values = values;
   return {
     len: len,
     value: value
@@ -1229,13 +1229,13 @@ var decodeDeviceObjPropertyRef = function(buffer, offset) {
   var arrayIndex = BACNET_ARRAY_ALL;
   if (!decodeIsContextTag(buffer, offset + len, 0)) return;
   len++;
-  var objectIdentifier = decodeObjectId(buffer, offset + len);
-  len += objectIdentifier.len;
+  var objectId = decodeObjectId(buffer, offset + len);
+  len += objectId.len;
   var result = decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   if (result.tagNumber !== 1) return;
-  var propertyIdentifier = decodeEnumerated(buffer, offset + len, result.value);
-  len += propertyIdentifier.len;
+  var id = decodeEnumerated(buffer, offset + len, result.value);
+  len += id.len;
   result = decodeTagNumberAndValue(buffer, offset + len);
   if (result.tagNumber === 2) {
     len += result.len;
@@ -1245,15 +1245,15 @@ var decodeDeviceObjPropertyRef = function(buffer, offset) {
   if (decodeIsContextTag(buffer, offset + len, 3)) {
     if (!isClosingTag(buffer[offset + len])) {
       len++;
-      objectIdentifier = decodeObjectId(buffer, offset + len);
-      len += objectIdentifier.len;
+      objectId = decodeObjectId(buffer, offset + len);
+      len += objectId.len;
     }
   }
   return {
     len: len,
     value: {
-      objectIdentifier: objectIdentifier,
-      propertyIdentifier: propertyIdentifier
+      objectId: objectId,
+      id: id
     }
   };
 };
@@ -1264,7 +1264,7 @@ var decodeReadAccessSpecification = module.exports.decodeReadAccessSpecification
   if (!decodeIsContextTag(buffer, offset + len, 0)) return;
   len++;
   var decodedValue = decodeObjectId(buffer, offset + len);
-  value.objectIdentifier = {
+  value.objectId = {
     type: decodedValue.objectType,
     instance: decodedValue.instance
   };
@@ -1280,16 +1280,16 @@ var decodeReadAccessSpecification = module.exports.decodeReadAccessSpecification
     if (result.tagNumber !== 0) return;
     if ((len + result.value) >= apduLen) return;
     decodedValue = decodeEnumerated(buffer, offset + len, result.value);
-    propertyRef.propertyIdentifier = decodedValue.value;
+    propertyRef.id = decodedValue.value;
     len += decodedValue.len;
-    propertyRef.propertyArrayIndex = BACNET_ARRAY_ALL;
+    propertyRef.index = BACNET_ARRAY_ALL;
     if (isContextSpecific(buffer[offset + len]) && !isClosingTag(buffer[offset + len])) {
       var tmp = decodeTagNumberAndValue(buffer, offset + len);
       if (tmp.tagNumber === 1) {
         len += tmp.len;
         if ((len + tmp.value) >= apduLen) return;
         decodedValue = decodeUnsigned(buffer, offset + len, tmp.value);
-        propertyRef.propertyArrayIndex = decodedValue.value;
+        propertyRef.index = decodedValue.value;
         len += decodedValue.len;
       }
     }
@@ -1297,7 +1297,7 @@ var decodeReadAccessSpecification = module.exports.decodeReadAccessSpecification
   }
   if (!decodeIsClosingTagNumber(buffer, offset + len, 1)) return;
   len++;
-  value.propertyReferences = propertyIdAndArrayIndex;
+  value.properties = propertyIdAndArrayIndex;
   return {
     len: len,
     value: value
@@ -1337,7 +1337,7 @@ var decodeCovSubscription = function(buffer, offset, apduLen) {
   if (result.tagNumber !== 1) return;
   decodedValue = decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.subscriptionProcessIdentifier = decodedValue.value;
+  value.subscriptionProcessId = decodedValue.value;
   if (!decodeIsClosingTagNumber(buffer, offset + len, 0)) return;
   len++;
   if (!decodeIsOpeningTagNumber(buffer, offset + len, 1)) return;
@@ -1347,7 +1347,7 @@ var decodeCovSubscription = function(buffer, offset, apduLen) {
   if (result.tagNumber !== 0) return;
   decodedValue = decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  value.monitoredObjectIdentifier = {
+  value.monitoredObjectId = {
     type: decodedValue.objectType,
     instance: decodedValue.instance
   };
@@ -1357,15 +1357,15 @@ var decodeCovSubscription = function(buffer, offset, apduLen) {
   decodedValue = decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
   value.monitoredProperty = {};
-  value.monitoredProperty.propertyIdentifier = decodedValue.value;
+  value.monitoredProperty.id = decodedValue.value;
   result = decodeTagNumberAndValue(buffer, offset + len);
   if (result.tagNumber === 2) {
     len += result.len;
     decodedValue = decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    value.monitoredProperty.propertyArrayIndex = decodedValue.value;
+    value.monitoredProperty.index = decodedValue.value;
   } else {
-    value.monitoredProperty.propertyArrayIndex = BACNET_ARRAY_ALL;
+    value.monitoredProperty.index = BACNET_ARRAY_ALL;
   }
   if (!decodeIsClosingTagNumber(buffer, offset + len, 1)) return;
   len++;

--- a/lib/bacnet-client.js
+++ b/lib/bacnet-client.js
@@ -254,7 +254,7 @@ module.exports = function(options) {
     } else if (service === baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_WHO_HAS) {
       result = baServices.decodeWhoHasBroadcast(buffer, offset, length);
       if (!result) return debug('Received invalid WhoHas message');
-      self.emit('whoHas', {address: address, lowLimit: result.lowLimit, highLimit: result.highLimit, objId: result.objId, objName: result.objName});
+      self.emit('whoHas', {address: address, lowLimit: result.lowLimit, highLimit: result.highLimit, objectId: result.objectId, objectName: result.objectName});
     } else if (service === baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_COV_NOTIFICATION) {
       result = baServices.decodeCOVNotify(buffer, offset, length);
       if (!result) return debug('Received invalid covNotifyUnconfirmed message');
@@ -468,9 +468,9 @@ module.exports = function(options) {
    * @param {number} objectInstance - The BACNET object instance to write.
    * @param {number} propertyId - The BACNET property id in the specified object to write.
    * @param {number} priority - The priority to be used for writing to the property.
-   * @param {object[]} valueList - A list of values to be written to the specified property.
-   * @param {BacnetApplicationTags} valueList.tag - The data-type of the value to be written.
-   * @param {number} valueList.value - The actual value to be written.
+   * @param {object[]} values - A list of values to be written to the specified property.
+   * @param {BacnetApplicationTags} values.tag - The data-type of the value to be written.
+   * @param {number} values.value - The actual value to be written.
    * @param {function} next - The callback containing an error, in case of a failure and value object in case of success.
    * @example
    * var bacnet = require('bacstack');
@@ -482,13 +482,13 @@ module.exports = function(options) {
    *   console.log('value: ', value);
    * });
    */
-  self.writeProperty = function(address, objectType, objectInstance, propertyId, priority, valueList, next) {
+  self.writeProperty = function(address, objectType, objectInstance, propertyId, priority, values, next) {
     var maxSegments = baEnum.BacnetMaxSegments.MAX_SEG65;
     var buffer = getBuffer();
     var invokeId = getInvokeId();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.BacnetNpduControls.EXPECTING_REPLY, address, null, DEFAULT_HOP_COUNT, baEnum.BacnetNetworkMessageTypes.NETWORK_MESSAGE_WHO_IS_ROUTER_TO_NETWORK, 0);
     baAdpu.encodeConfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY, maxSegments, baEnum.BacnetMaxAdpu.MAX_APDU1476, invokeId, 0, 0);
-    baServices.encodeWriteProperty(buffer, objectType, objectInstance, propertyId, baAsn1.BACNET_ARRAY_ALL, priority, valueList);
+    baServices.encodeWriteProperty(buffer, objectType, objectInstance, propertyId, baAsn1.BACNET_ARRAY_ALL, priority, values);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(invokeId, function(err, data) {
@@ -501,18 +501,18 @@ module.exports = function(options) {
    * @function bacstack.readPropertyMultiple
    * @param {string} address - IP address of the target device.
    * @param {object[]} propertyIdAndArrayIndex - List of object and property specifications to be read.
-   * @param {object} propertyIdAndArrayIndex.objectIdentifier - Specifies which object to read.
-   * @param {number} propertyIdAndArrayIndex.objectIdentifier.type - The BACNET object type to read.
-   * @param {number} propertyIdAndArrayIndex.objectIdentifier.instance - The BACNET object instance to read.
-   * @param {object[]} propertyIdAndArrayIndex.propertyReferences - List of properties to be read.
-   * @param {number} propertyIdAndArrayIndex.propertyReferences.propertyIdentifier - The BACNET property id in the specified object to read. Also supports 8 for all properties.
+   * @param {object} propertyIdAndArrayIndex.objectId - Specifies which object to read.
+   * @param {number} propertyIdAndArrayIndex.objectId.type - The BACNET object type to read.
+   * @param {number} propertyIdAndArrayIndex.objectId.instance - The BACNET object instance to read.
+   * @param {object[]} propertyIdAndArrayIndex.properties - List of properties to be read.
+   * @param {number} propertyIdAndArrayIndex.properties.id - The BACNET property id in the specified object to read. Also supports 8 for all properties.
    * @param {function} next - The callback containing an error, in case of a failure and value object in case of success.
    * @example
    * var bacnet = require('bacstack');
    * var client = new bacnet();
    *
    * var requestArray = [
-   *   {objectIdentifier: {type: 8, instance: 4194303}, propertyReferences: [{propertyIdentifier: 8}]}
+   *   {objectId: {type: 8, instance: 4194303}, properties: [{id: 8}]}
    * ];
    * client.readPropertyMultiple('192.168.1.43', requestArray, function(err, value) {
    *   console.log('value: ', value);
@@ -540,39 +540,39 @@ module.exports = function(options) {
    * The writePropertyMultiple command writes multiple properties in multiple objects to a device.
    * @function bacstack.writePropertyMultiple
    * @param {string} address - IP address of the target device.
-   * @param {object[]} valueList - List of object and property specifications to be written.
-   * @param {object} valueList.objectIdentifier - Specifies which object to read.
-   * @param {number} valueList.objectIdentifier.type - The BACNET object type to read.
-   * @param {number} valueList.objectIdentifier.instance - The BACNET object instance to read.
-   * @param {object[]} valueList.values - List of properties to be written.
-   * @param {object} valueList.values.property - Property specifications to be written.
-   * @param {number} valueList.values.property.propertyIdentifier - The BACNET property id in the specified object to write.
-   * @param {number} valueList.values.property.propertyArrayIndex - The array index of the property to be written.
-   * @param {object[]} valueList.values.value - A list of values to be written to the specified property.
-   * @param {BacnetApplicationTags} valueList.values.value.tag - The data-type of the value to be written.
-   * @param {object} valueList.values.value.value - The actual value to be written.
-   * @param {number} valueList.values.priority - The priority to be used for writing to the property.
+   * @param {object[]} values - List of object and property specifications to be written.
+   * @param {object} values.objectId - Specifies which object to read.
+   * @param {number} values.objectId.type - The BACNET object type to read.
+   * @param {number} values.objectId.instance - The BACNET object instance to read.
+   * @param {object[]} values.values - List of properties to be written.
+   * @param {object} values.values.property - Property specifications to be written.
+   * @param {number} values.values.property.id - The BACNET property id in the specified object to write.
+   * @param {number} values.values.property.index - The array index of the property to be written.
+   * @param {object[]} values.values.value - A list of values to be written to the specified property.
+   * @param {BacnetApplicationTags} values.values.value.tag - The data-type of the value to be written.
+   * @param {object} values.values.value.value - The actual value to be written.
+   * @param {number} values.values.priority - The priority to be used for writing to the property.
    * @param {function} next - The callback containing an error, in case of a failure and value object in case of success.
    * @example
    * var bacnet = require('bacstack');
    * var client = new bacnet();
    *
-   * var valueList = [
-   *   {objectIdentifier: {type: 8, instance: 44301}, values: [
-   *     {property: {propertyIdentifier: 28, propertyArrayIndex: 12}, value: [{type: bacnet.enum.BacnetApplicationTags.BACNET_APPLICATION_TAG_BOOLEAN, value: true}], priority: 8}
+   * var values = [
+   *   {objectId: {type: 8, instance: 44301}, values: [
+   *     {property: {id: 28, index: 12}, value: [{type: bacnet.enum.BacnetApplicationTags.BACNET_APPLICATION_TAG_BOOLEAN, value: true}], priority: 8}
    *   ]}
    * ];
-   * client.writePropertyMultiple('192.168.1.43', valueList, function(err, value) {
+   * client.writePropertyMultiple('192.168.1.43', values, function(err, value) {
    *   console.log('value: ', value);
    * });
    */
-  self.writePropertyMultiple = function(address, valueList, next) {
+  self.writePropertyMultiple = function(address, values, next) {
     var maxSegments = baEnum.BacnetMaxSegments.MAX_SEG65;
     var buffer = getBuffer();
     var invokeId = getInvokeId();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.BacnetNpduControls.EXPECTING_REPLY, address);
     baAdpu.encodeConfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROP_MULTIPLE, maxSegments, baEnum.BacnetMaxAdpu.MAX_APDU1476, invokeId);
-    baServices.encodeWriteObjectMultiple(buffer, valueList);
+    baServices.encodeWriteObjectMultiple(buffer, values);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(invokeId, function(err, data) {
@@ -720,13 +720,13 @@ module.exports = function(options) {
     });
   };
 
-  self.createObject = function(address, objectId, valueList, next) {
+  self.createObject = function(address, objectId, values, next) {
     var maxSegments = baEnum.BacnetMaxSegments.MAX_SEG65;
     var buffer = getBuffer();
     var invokeId = getInvokeId();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.BacnetNpduControls.EXPECTING_REPLY, address);
     baAdpu.encodeConfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_CREATE_OBJECT, maxSegments, baEnum.BacnetMaxAdpu.MAX_APDU1476, invokeId, 0, 0);
-    baServices.encodeCreateObject(buffer, objectId, valueList);
+    baServices.encodeCreateObject(buffer, objectId, values);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(invokeId, function(err, data) {
@@ -750,13 +750,13 @@ module.exports = function(options) {
     });
   };
 
-  self.removeListElement = function(address, objectId, reference, valueList, next) {
+  self.removeListElement = function(address, objectId, reference, values, next) {
     var maxSegments = baEnum.BacnetMaxSegments.MAX_SEG65;
     var buffer = getBuffer();
     var invokeId = getInvokeId();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.BacnetNpduControls.EXPECTING_REPLY, address);
     baAdpu.encodeConfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_REMOVE_LIST_ELEMENT, maxSegments, baEnum.BacnetMaxAdpu.MAX_APDU1476, invokeId, 0, 0);
-    baServices.encodeAddListElement(buffer, objectId, reference.propertyIdentifier, reference.propertyArrayIndex, valueList);
+    baServices.encodeAddListElement(buffer, objectId, reference.id, reference.index, values);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(invokeId, function(err, data) {
@@ -765,13 +765,13 @@ module.exports = function(options) {
     });
   };
 
-  self.addListElement = function(address, objectId, reference, valueList, next) {
+  self.addListElement = function(address, objectId, reference, values, next) {
     var maxSegments = baEnum.BacnetMaxSegments.MAX_SEG65;
     var buffer = getBuffer();
     var invokeId = getInvokeId();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.BacnetNpduControls.EXPECTING_REPLY, address);
     baAdpu.encodeConfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_ADD_LIST_ELEMENT, maxSegments, baEnum.BacnetMaxAdpu.MAX_APDU1476, invokeId, 0, 0);
-    baServices.encodeAddListElement(buffer, objectId, reference.propertyIdentifier, reference.propertyArrayIndex, valueList);
+    baServices.encodeAddListElement(buffer, objectId, reference.id, reference.index, values);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(invokeId, function(err, data) {
@@ -833,7 +833,7 @@ module.exports = function(options) {
     var buffer = getBuffer();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE, receiver);
     baAdpu.encodeComplexAck(buffer, baEnum.BacnetPduTypes.PDU_TYPE_COMPLEX_ACK, baEnum.BacnetConfirmedServices.SERVICE_CONFIRMED_READ_PROPERTY, invokeId);
-    baServices.encodeReadPropertyAcknowledge(buffer, objectId, property.propertyIdentifier, property.propertyArrayIndex, value);
+    baServices.encodeReadPropertyAcknowledge(buffer, objectId, property.id, property.index, value);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, receiver);
   };
@@ -856,11 +856,11 @@ module.exports = function(options) {
     transport.send(buffer.buffer, buffer.offset, transport.getBroadcastAddress());
   };
 
-  self.iHaveResponse = function(deviceId, objId, objName) {
+  self.iHaveResponse = function(deviceId, objectId, objectName) {
     var buffer = getBuffer();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE, transport.getBroadcastAddress());
     baAdpu.EecodeUnconfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_I_HAVE);
-    baServices.EncodeIhaveBroadcast(buffer, deviceId, objId, objName);
+    baServices.EncodeIhaveBroadcast(buffer, deviceId, objectId, objectName);
     baBvlc.encode(buffer.buffer, baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_BROADCAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, transport.getBroadcastAddress());
   };

--- a/lib/bacnet-services.js
+++ b/lib/bacnet-services.js
@@ -87,12 +87,12 @@ module.exports.decodeWhoHasBroadcast = function(buffer, offset, apduLen) {
   if (result.tagNumber === 2) {
     decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
     len += decodedValue.len;
-    value.objId = {type: decodedValue.objectType, instance: decodedValue.instance};
+    value.objectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   }
   if (result.tagNumber === 3) {
     decodedValue = baAsn1.decodeCharacterString(buffer, offset + len, apduLen - (offset + len), result.value);
     len += decodedValue.len;
-    value.objName = decodedValue.value;
+    value.objectName = decodedValue.value;
   }
   value.len = len;
   return value;
@@ -524,15 +524,15 @@ module.exports.decodeReadRange = function(buffer, offset, apduLen) {
   if (result.tagNumber !== 1) return;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
-  property.propertyIdentifier = decodedValue.value;
+  property.id = decodedValue.value;
   if (len < apduLen && baAsn1.decodeIsContextTag(buffer, offset + len, 2)) {
     result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
     len += result.len;
     decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    property.propertyArrayIndex = decodedValue.value;
+    property.index = decodedValue.value;
   } else {
-    property.propertyArrayIndex = baAsn1.BACNET_ARRAY_ALL;
+    property.index = baAsn1.BACNET_ARRAY_ALL;
   }
   if (len < apduLen) {
     result = baAsn1.decodeTagNumber(buffer, offset + len);
@@ -624,15 +624,15 @@ module.exports.decodeReadProperty = function(buffer, offset, apduLen) {
   if (result.tagNumber !== 1) return;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
-  property.propertyIdentifier = decodedValue.value;
-  property.propertyArrayIndex = baAsn1.BACNET_ARRAY_ALL;
+  property.id = decodedValue.value;
+  property.index = baAsn1.BACNET_ARRAY_ALL;
   if (len < apduLen) {
     result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
     len += result.len;
     if ((result.tagNumber === 2) && (len < apduLen)) {
       decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
       len += decodedValue.len;
-      property.propertyArrayIndex = decodedValue.value;
+      property.index = decodedValue.value;
     } else {
       return;
     }
@@ -645,14 +645,14 @@ module.exports.decodeReadProperty = function(buffer, offset, apduLen) {
   };
 };
 
-module.exports.encodeReadPropertyAcknowledge = function(buffer, objectId, propertyId, arrayIndex, valueList) {
+module.exports.encodeReadPropertyAcknowledge = function(buffer, objectId, propertyId, arrayIndex, values) {
   baAsn1.encodeContextObjectId(buffer, 0, objectId.type, objectId.instance);
   baAsn1.encodeContextEnumerated(buffer, 1, propertyId);
   if (arrayIndex !== baAsn1.BACNET_ARRAY_ALL) {
     baAsn1.encodeContextUnsigned(buffer, 2, arrayIndex);
   }
   baAsn1.encodeOpeningTag(buffer, 3);
-  valueList.forEach(function(value) {
+  values.forEach(function(value) {
     baAsn1.bacappEncodeApplicationData(buffer, value);
   });
   baAsn1.encodeClosingTag(buffer, 3);
@@ -674,24 +674,25 @@ module.exports.decodeReadPropertyAcknowledge = function(buffer, offset, apduLen)
   if (result.tagNumber !== 1) return;
   result = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += result.len;
-  property.propertyIdentifier = result.value;
+  property.id = result.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   if (result.tagNumber === 2) {
     len += result.len;
     decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    property.propertyArrayIndex = decodedValue.value;
+    property.index = decodedValue.value;
   } else {
-    property.propertyArrayIndex = baAsn1.BACNET_ARRAY_ALL;
+    property.index = baAsn1.BACNET_ARRAY_ALL;
   }
-  var valueList = [];
+  var values = [];
   if (!baAsn1.decodeIsOpeningTagNumber(buffer, offset + len, 3)) return;
   len++;
   while ((apduLen - len) > 1) {
-    result = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, objectId.type, property.propertyIdentifier);
+    result = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, objectId.type, property.id);
     if (!result) return;
     len += result.len;
-    valueList.push(result);
+    delete result.len;
+    values.push(result);
   }
   if (!baAsn1.decodeIsClosingTagNumber(buffer, offset + len, 3)) return;
   len++;
@@ -699,7 +700,7 @@ module.exports.decodeReadPropertyAcknowledge = function(buffer, offset, apduLen)
     len: len,
     objectId: objectId,
     property: property,
-    valueList: valueList
+    values: values
   };
 };
 
@@ -745,14 +746,14 @@ module.exports.decodeReadPropertyMultipleAcknowledge = function(buffer, offset, 
   };
 };
 
-module.exports.encodeWriteProperty = function(buffer, objectType, objectInstance, propertyId, arrayIndex, priority, valueList) {
+module.exports.encodeWriteProperty = function(buffer, objectType, objectInstance, propertyId, arrayIndex, priority, values) {
   baAsn1.encodeContextObjectId(buffer, 0, objectType, objectInstance);
   baAsn1.encodeContextEnumerated(buffer, 1, propertyId);
   if (arrayIndex !== baAsn1.BACNET_ARRAY_ALL) {
     baAsn1.encodeContextUnsigned(buffer, 2, arrayIndex);
   }
   baAsn1.encodeOpeningTag(buffer, 3);
-  valueList.forEach(function(value) {
+  values.forEach(function(value) {
     baAsn1.bacappEncodeApplicationData(buffer, value);
   });
   baAsn1.encodeClosingTag(buffer, 3);
@@ -781,26 +782,27 @@ module.exports.decodeWriteProperty = function(buffer, offset, apduLen) {
   if (result.tagNumber !== 1) return;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.property.propertyIdentifier = decodedValue.value;
+  value.property.id = decodedValue.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   if (result.tagNumber === 2) {
     len += result.len;
     decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    value.property.propertyArrayIndex = decodedValue.value;
+    value.property.index = decodedValue.value;
   } else {
-    value.property.propertyArrayIndex = baAsn1.BACNET_ARRAY_ALL;
+    value.property.index = baAsn1.BACNET_ARRAY_ALL;
   }
   if (!baAsn1.decodeIsOpeningTagNumber(buffer, offset + len, 3)) return;
   len++;
-  var valueList = [];
+  var values = [];
   while ((apduLen - len) > 1 && !baAsn1.decodeIsClosingTagNumber(buffer, offset + len, 3)) {
-    decodedValue = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, objectId.type, value.property.propertyIdentifier);
+    decodedValue = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, objectId.type, value.property.id);
     if (!decodedValue) return;
     len += decodedValue.len;
-    valueList.push(decodedValue.value);
+    delete decodedValue.len;
+    values.push(decodedValue);
   }
-  value.value = valueList;
+  value.value = values;
   if (!baAsn1.decodeIsClosingTagNumber(buffer, offset + len, 3)) return;
   len++;
   value.priority = baAsn1.BACNET_MAX_PRIORITY;
@@ -824,13 +826,13 @@ module.exports.decodeWriteProperty = function(buffer, offset, apduLen) {
   };
 };
 
-var encodeWritePropertyMultiple = module.exports.encodeWritePropertyMultiple = function(buffer, objectId, valueList) {
+var encodeWritePropertyMultiple = module.exports.encodeWritePropertyMultiple = function(buffer, objectId, values) {
   baAsn1.encodeContextObjectId(buffer, 0, objectId.type, objectId.instance);
   baAsn1.encodeOpeningTag(buffer, 1);
-  valueList.forEach(function(pValue) {
-    baAsn1.encodeContextEnumerated(buffer, 0, pValue.property.propertyIdentifier);
-    if (pValue.property.propertyArrayIndex !== baAsn1.BACNET_ARRAY_ALL) {
-      baAsn1.encodeContextUnsigned(buffer, 1, pValue.property.propertyArrayIndex);
+  values.forEach(function(pValue) {
+    baAsn1.encodeContextEnumerated(buffer, 0, pValue.property.id);
+    if (pValue.property.index !== baAsn1.BACNET_ARRAY_ALL) {
+      baAsn1.encodeContextUnsigned(buffer, 1, pValue.property.index);
     }
     baAsn1.encodeOpeningTag(buffer, 2);
     pValue.value.forEach(function(value) {
@@ -881,13 +883,14 @@ module.exports.decodeWritePropertyMultiple = function(buffer, offset, apduLen) {
       result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
       len += result.len;
     }
-    newEntry.property = {propertyId: propertyId, arrayIndex: arrayIndex};
+    newEntry.property = {id: propertyId, index: arrayIndex};
     if ((result.tagNumber !== 2) || (!baAsn1.decodeIsOpeningTag(buffer, offset + len - 1))) return;
     var values = [];
     while ((len + offset) <= buffer.length && !baAsn1.decodeIsClosingTag(buffer, offset + len)) {
       var value = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, objectId.type, propertyId);
       if (!value) return;
       len += value.len;
+      delete value.len;
       values.push(value);
     }
     len++;
@@ -910,13 +913,13 @@ module.exports.decodeWritePropertyMultiple = function(buffer, offset, apduLen) {
   return {
     len: len,
     objectId: objectId,
-    valuesRefs: _values
+    values: _values
   };
 };
 
-module.exports.encodeWriteObjectMultiple = function(buffer, valueList) {
-  valueList.forEach(function(object) {
-    encodeWritePropertyMultiple(buffer, object.objectIdentifier, object.values);
+module.exports.encodeWriteObjectMultiple = function(buffer, values) {
+  values.forEach(function(object) {
+    encodeWritePropertyMultiple(buffer, object.objectId, object.values);
   });
 };
 
@@ -971,9 +974,9 @@ module.exports.decodeError = function(buffer, offset) {
   };
 };
 
-module.exports.encodeSubscribeCOV = function(buffer, subscriberProcessIdentifier, monitoredObjectIdentifier, cancellationRequest, issueConfirmedNotifications, lifetime) {
-  baAsn1.encodeContextUnsigned(buffer, 0, subscriberProcessIdentifier);
-  baAsn1.encodeContextObjectId(buffer, 1, monitoredObjectIdentifier.type, monitoredObjectIdentifier.instance);
+module.exports.encodeSubscribeCOV = function(buffer, subscriberProcessId, monitoredObjectId, cancellationRequest, issueConfirmedNotifications, lifetime) {
+  baAsn1.encodeContextUnsigned(buffer, 0, subscriberProcessId);
+  baAsn1.encodeContextObjectId(buffer, 1, monitoredObjectId.type, monitoredObjectId.instance);
   if (!cancellationRequest) {
     baAsn1.encodeContextBoolean(buffer, 2, issueConfirmedNotifications);
     baAsn1.encodeContextUnsigned(buffer, 3, lifetime);
@@ -990,13 +993,13 @@ module.exports.decodeSubscribeCOV = function(buffer, offset, apduLen) {
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.subscriberProcessIdentifier = decodedValue.value;
+  value.subscriberProcessId = decodedValue.value;
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 1)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  value.monitoredObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  value.monitoredObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   value.cancellationRequest = true;
   if (len < apduLen) {
     value.issueConfirmedNotifications = false;
@@ -1020,17 +1023,17 @@ module.exports.decodeSubscribeCOV = function(buffer, offset, apduLen) {
   return value;
 };
 
-module.exports.encodeSubscribeProperty = function(buffer, subscriberProcessIdentifier, monitoredObjectIdentifier, cancellationRequest, issueConfirmedNotifications, lifetime, monitoredProperty, covIncrementPresent, covIncrement) {
-  baAsn1.encodeContextUnsigned(buffer, 0, subscriberProcessIdentifier);
-  baAsn1.encodeContextObjectId(buffer, 1, monitoredObjectIdentifier.type, monitoredObjectIdentifier.instance);
+module.exports.encodeSubscribeProperty = function(buffer, subscriberProcessId, monitoredObjectId, cancellationRequest, issueConfirmedNotifications, lifetime, monitoredProperty, covIncrementPresent, covIncrement) {
+  baAsn1.encodeContextUnsigned(buffer, 0, subscriberProcessId);
+  baAsn1.encodeContextObjectId(buffer, 1, monitoredObjectId.type, monitoredObjectId.instance);
   if (!cancellationRequest) {
     baAsn1.encodeContextBoolean(buffer, 2, issueConfirmedNotifications);
     baAsn1.encodeContextUnsigned(buffer, 3, lifetime);
   }
   baAsn1.encodeOpeningTag(buffer, 4);
-  baAsn1.encodeContextEnumerated(buffer, 0, monitoredProperty.propertyIdentifier);
-  if (monitoredProperty.propertyArrayIndex !== baAsn1.BACNET_ARRAY_ALL) {
-    baAsn1.encodeContextUnsigned(buffer, 1, monitoredProperty.propertyArrayIndex);
+  baAsn1.encodeContextEnumerated(buffer, 0, monitoredProperty.id);
+  if (monitoredProperty.index !== baAsn1.BACNET_ARRAY_ALL) {
+    baAsn1.encodeContextUnsigned(buffer, 1, monitoredProperty.index);
   }
   baAsn1.encodeClosingTag(buffer, 4);
   if (covIncrementPresent) {
@@ -1048,13 +1051,13 @@ module.exports.decodeSubscribeProperty = function(buffer, offset) {
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.subscriberProcessIdentifier = decodedValue.value;
+  value.subscriberProcessId = decodedValue.value;
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 1)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  value.monitoredObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  value.monitoredObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   value.cancellationRequest = true;
   value.issueConfirmedNotifications = false;
   if (baAsn1.decodeIsContextTag(buffer, offset + len, 2)) {
@@ -1080,14 +1083,14 @@ module.exports.decodeSubscribeProperty = function(buffer, offset) {
   len += result.len;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.monitoredProperty.propertyIdentifier = decodedValue.value;
-  value.monitoredProperty.propertyArrayIndex = baAsn1.BACNET_ARRAY_ALL;
+  value.monitoredProperty.id = decodedValue.value;
+  value.monitoredProperty.index = baAsn1.BACNET_ARRAY_ALL;
   if (baAsn1.decodeIsContextTag(buffer, offset + len, 1)) {
     result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
     len += result.len;
     decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    value.monitoredProperty.propertyArrayIndex = decodedValue.value;
+    value.monitoredProperty.index = decodedValue.value;
   }
   if (!baAsn1.decodeIsClosingTagNumber(buffer, offset + len, 4)) return;
   len++;
@@ -1104,9 +1107,9 @@ module.exports.decodeSubscribeProperty = function(buffer, offset) {
 };
 
 module.exports.encodeEventNotifyData = function(buffer, data) {
-  baAsn1.encodeContextUnsigned(buffer, 0, data.processIdentifier);
-  baAsn1.encodeContextObjectId(buffer, 1, data.initiatingObjectIdentifier.type, data.initiatingObjectIdentifier.instance);
-  baAsn1.encodeContextObjectId(buffer, 2, data.eventObjectIdentifier.type, data.eventObjectIdentifier.instance);
+  baAsn1.encodeContextUnsigned(buffer, 0, data.processId);
+  baAsn1.encodeContextObjectId(buffer, 1, data.initiatingObjectId.type, data.initiatingObjectId.instance);
+  baAsn1.encodeContextObjectId(buffer, 2, data.eventObjectId.type, data.eventObjectId.instance);
   baAsn1.bacappEncodeContextTimestamp(buffer, 3, data.timeStamp);
   baAsn1.encodeContextUnsigned(buffer, 4, data.notificationClass);
   baAsn1.encodeContextUnsigned(buffer, 5, data.priority);
@@ -1224,19 +1227,19 @@ module.exports.decodeEventNotifyData = function(buffer, offset) {
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  eventData.processIdentifier = decodedValue.value;
+  eventData.processId = decodedValue.value;
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 1)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  eventData.initiatingObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  eventData.initiatingObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 2)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  eventData.eventObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  eventData.eventObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 3)) return;
   len += 2;
   decodedValue = baAsn1.decodeApplicationDate(buffer, offset + len);
@@ -1341,13 +1344,13 @@ module.exports.decodeReadRangeAcknowledge = function(buffer, offset, apduLen) {
   if (result.tagNumber !== 1) return;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
-  property.propertyIdentifier = decodedValue.value;
+  property.id = decodedValue.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   if ((result.tagNumber === 2) && (len < apduLen)) {
     decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    property.propertyArrayIndex = decodedValue.value;
+    property.index = decodedValue.value;
   } else {
     decodedValue = baAsn1.decodeBitstring(buffer, offset + len, 2);
     len += decodedValue.len;
@@ -1383,15 +1386,15 @@ module.exports.encodeDeleteObject = function(buffer, objectId) {
   baAsn1.encodeApplicationObjectId(buffer, objectId.type, objectId.instance);
 };
 
-module.exports.encodeCreateObject = function(buffer, objectId, valueList) {
+module.exports.encodeCreateObject = function(buffer, objectId, values) {
   baAsn1.encodeOpeningTag(buffer, 0);
   baAsn1.encodeContextObjectId(buffer, 1, objectId.type, objectId.instance);
   baAsn1.encodeClosingTag(buffer, 0);
   baAsn1.encodeOpeningTag(buffer, 1);
-  valueList.forEach(function(propertyValue) {
-    baAsn1.encodeContextEnumerated(buffer, 0, propertyValue.property.propertyIdentifier);
-    if (propertyValue.property.propertyArrayIndex !== baAsn1.BACNET_ARRAY_ALL) {
-      baAsn1.encodeContextUnsigned(buffer, 1, propertyValue.property.propertyArrayIndex);
+  values.forEach(function(propertyValue) {
+    baAsn1.encodeContextEnumerated(buffer, 0, propertyValue.property.id);
+    if (propertyValue.property.index !== baAsn1.BACNET_ARRAY_ALL) {
+      baAsn1.encodeContextUnsigned(buffer, 1, propertyValue.property.index);
     }
     baAsn1.encodeOpeningTag(buffer, 2);
     propertyValue.value.forEach(function(value) {
@@ -1410,7 +1413,7 @@ module.exports.decodeCreateObject = function(buffer, offset, apduLen) {
   var result;
   var decodedValue;
   var objectId;
-  var valuesRefs = [];
+  var valueList = [];
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   if ((result.tagNumber === 0) && (apduLen > len)) {
@@ -1445,13 +1448,14 @@ module.exports.decodeCreateObject = function(buffer, offset, apduLen) {
       result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
       len += result.len;
     }
-    newEntry.property = {propertyId: propertyId, arrayIndex: arraIndex};
+    newEntry.property = {id: propertyId, index: arraIndex};
     if ((result.tagNumber === 2) && (baAsn1.decodeIsOpeningTag(buffer, offset + len - 1))) {
       var values = [];
       while (!baAsn1.decodeIsClosingTag(buffer, offset + len)) {
         decodedValue = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, objectId.type, propertyId);
         if (!decodedValue) return;
         len += decodedValue.len;
+        delete decodedValue.len;
         values.push(decodedValue);
       }
       len++;
@@ -1459,27 +1463,27 @@ module.exports.decodeCreateObject = function(buffer, offset, apduLen) {
     } else {
       return;
     }
-    valuesRefs.push(newEntry);
+    valueList.push(newEntry);
   }
   if (!baAsn1.decodeIsClosingTagNumber(buffer, offset + len, 1)) return;
   len++;
   return {
     len: len,
     objectId: objectId,
-    values: valuesRefs
+    values: valueList
   };
 };
 
-module.exports.encodeCOVNotify = function(buffer, subscriberProcessIdentifier, initiatingDeviceIdentifier, monitoredObjectIdentifier, timeRemaining, values) {
-  baAsn1.encodeContextUnsigned(buffer, 0, subscriberProcessIdentifier);
-  baAsn1.encodeContextObjectId(buffer, 1, baEnum.BacnetObjectTypes.OBJECT_DEVICE, initiatingDeviceIdentifier);
-  baAsn1.encodeContextObjectId(buffer, 2, monitoredObjectIdentifier.type, monitoredObjectIdentifier.instance);
+module.exports.encodeCOVNotify = function(buffer, subscriberProcessId, initiatingDeviceId, monitoredObjectId, timeRemaining, values) {
+  baAsn1.encodeContextUnsigned(buffer, 0, subscriberProcessId);
+  baAsn1.encodeContextObjectId(buffer, 1, baEnum.BacnetObjectTypes.OBJECT_DEVICE, initiatingDeviceId);
+  baAsn1.encodeContextObjectId(buffer, 2, monitoredObjectId.type, monitoredObjectId.instance);
   baAsn1.encodeContextUnsigned(buffer, 3, timeRemaining);
   baAsn1.encodeOpeningTag(buffer, 4);
   values.forEach(function(value) {
-    baAsn1.encodeContextEnumerated(buffer, 0, value.property.propertyIdentifier);
-    if (value.property.propertyArrayIndex === baAsn1.BACNET_ARRAY_ALL) {
-      baAsn1.encodeContextUnsigned(buffer, 1, value.property.propertyArrayIndex);
+    baAsn1.encodeContextEnumerated(buffer, 0, value.property.id);
+    if (value.property.index === baAsn1.BACNET_ARRAY_ALL) {
+      baAsn1.encodeContextUnsigned(buffer, 1, value.property.index);
     }
     baAsn1.encodeOpeningTag(buffer, 2);
     value.value.forEach(function(v) {
@@ -1503,19 +1507,19 @@ module.exports.decodeCOVNotify = function(buffer, offset, apduLen) {
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  var subscriberProcessIdentifier = decodedValue.value;
+  var subscriberProcessId = decodedValue.value;
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 1)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  var initiatingDeviceIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  var initiatingDeviceId = {type: decodedValue.objectType, instance: decodedValue.instance};
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 2)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  var monitoredObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  var monitoredObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   if (!baAsn1.decodeIsContextTag(buffer, offset + len, 3)) return;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
@@ -1533,23 +1537,24 @@ module.exports.decodeCOVNotify = function(buffer, offset, apduLen) {
     len += result.len;
     decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
     len += decodedValue.len;
-    newEntry.property.propertyId = decodedValue.value;
+    newEntry.property.id = decodedValue.value;
     if (baAsn1.decodeIsContextTag(buffer, offset + len, 1)) {
       result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
       len += result.len;
       decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
       len += decodedValue.len;
-      newEntry.property.arrayIndex = decodedValue.value;
+      newEntry.property.index = decodedValue.value;
     } else {
-      newEntry.property.arrayIndex = baAsn1.BACNET_ARRAY_ALL;
+      newEntry.property.index = baAsn1.BACNET_ARRAY_ALL;
     }
     if (!baAsn1.decodeIsOpeningTagNumber(buffer, offset + len, 2)) return;
     len++;
     var properties = [];
     while ((apduLen - len) > 1 && !baAsn1.decodeIsClosingTagNumber(buffer, offset + len, 2)) {
-      decodedValue = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, monitoredObjectIdentifier.type, newEntry.property.propertyIdentifier);
+      decodedValue = baAsn1.bacappDecodeApplicationData(buffer, offset + len, apduLen + offset, monitoredObjectId.type, newEntry.property.id);
       if (!decodedValue) return;
       len += decodedValue.len;
+      delete decodedValue.len;
       properties.push(decodedValue);
     }
     newEntry.value = properties;
@@ -1567,9 +1572,9 @@ module.exports.decodeCOVNotify = function(buffer, offset, apduLen) {
   }
   return {
     len: len,
-    subscriberProcessIdentifier: subscriberProcessIdentifier,
-    initiatingDeviceIdentifier: initiatingDeviceIdentifier,
-    monitoredObjectIdentifier: monitoredObjectIdentifier,
+    subscriberProcessId: subscriberProcessId,
+    initiatingDeviceId: initiatingDeviceId,
+    monitoredObjectId: monitoredObjectId,
     timeRemaining: timeRemaining,
     values: values
   };
@@ -1613,10 +1618,10 @@ module.exports.decodeAlarmSummary = function(buffer, offset, apduLen) {
   };
 };
 
-module.exports.encodeAlarmAcknowledge = function(buffer, ackProcessIdentifier, eventObjectIdentifier, eventStateAcked, ackSource, eventTimeStamp, ackTimeStamp) {
-  baAsn1.encodeContextUnsigned(buffer, 0, ackProcessIdentifier);
-  baAsn1.encodeContextObjectId(buffer, 1, eventObjectIdentifier.type, eventObjectIdentifier.instance);
-  baAsn1.encodeContextEnumerated(buffer, 2, eventStateAcked);
+module.exports.encodeAlarmAcknowledge = function(buffer, ackProcessId, eventObjectId, eventStateAcknowledged, ackSource, eventTimeStamp, ackTimeStamp) {
+  baAsn1.encodeContextUnsigned(buffer, 0, ackProcessId);
+  baAsn1.encodeContextObjectId(buffer, 1, eventObjectId.type, eventObjectId.instance);
+  baAsn1.encodeContextEnumerated(buffer, 2, eventStateAcknowledged);
   baAsn1.bacappEncodeContextTimestamp(buffer, 3, eventTimeStamp);
   baAsn1.encodeContextCharacterString(buffer, 4, ackSource);
   baAsn1.bacappEncodeContextTimestamp(buffer, 5, ackTimeStamp);
@@ -1633,17 +1638,17 @@ module.exports.decodeAlarmAcknowledge = function(buffer, offset, apduLen) {
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.ackProcessIdentifier = decodedValue.value;
+  value.acknowledgedProcessId = decodedValue.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  value.eventObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  value.eventObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.eventStateAcked = decodedValue.value;
+  value.eventStateAcknowledged = decodedValue.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
@@ -1670,7 +1675,7 @@ module.exports.decodeAlarmAcknowledge = function(buffer, offset, apduLen) {
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeCharacterString(buffer, offset + len, apduLen - (offset + len), result.value);
-  value.ackSource = decodedValue.value;
+  value.acknowledgeSource = decodedValue.value;
   len += decodedValue.len;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
@@ -1679,11 +1684,11 @@ module.exports.decodeAlarmAcknowledge = function(buffer, offset, apduLen) {
   if (result.tagNumber === baEnum.BacnetTimestampTags.TIME_STAMP_TIME) {
     decodedValue = baAsn1.decodeBacnetTime(buffer, offset + len, result.value);
     len += decodedValue.len;
-    value.ackTimeStamp = decodedValue.value;
+    value.acknowledgeTimeStamp = decodedValue.value;
   } else if (result.tagNumber === baEnum.BacnetTimestampTags.TIME_STAMP_SEQUENCE) {
     decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
     len += decodedValue.len;
-    value.ackTimeStamp = decodedValue.value;
+    value.acknowledgeTimeStamp = decodedValue.value;
   } else if (result.tagNumber === baEnum.BacnetTimestampTags.TIME_STAMP_DATETIME) {
     date = baAsn1.decodeApplicationDate(buffer, offset + len);
     len += date.len;
@@ -1691,7 +1696,7 @@ module.exports.decodeAlarmAcknowledge = function(buffer, offset, apduLen) {
     time = baAsn1.decodeApplicationTime(buffer, offset + len);
     len += time.len;
     time = time.value.value;
-    value.ackTimeStamp = new Date(date.getFullYear(), date.getMonth(), date.getDate(), time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
+    value.acknowledgeTimeStamp = new Date(date.getFullYear(), date.getMonth(), date.getDate(), time.getHours(), time.getMinutes(), time.getSeconds(), time.getMilliseconds());
     len++;
   }
   len++;
@@ -1705,7 +1710,7 @@ module.exports.encodeEventInformation = function(buffer, events, moreEvents) {
   events.forEach(function(event) {
     baAsn1.encodeContextObjectId(buffer, 0, event.objectId.type, event.objectId.instance);
     baAsn1.encodeContextEnumerated(buffer, 1, event.eventState);
-    baAsn1.encodeContextBitstring(buffer, 2, event.ackedTransitions);
+    baAsn1.encodeContextBitstring(buffer, 2, event.acknowledgedTransitions);
     baAsn1.encodeOpeningTag(buffer, 3);
     for (i = 0; i < 3; i++) {
       baAsn1.encodeApplicationDate(buffer, event.eventTimeStamps[i]);
@@ -1738,7 +1743,7 @@ module.exports.decodeEventInformation = function(buffer, offset, apduLen) {
     len += result.len;
     decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
     len += decodedValue.len;
-    value.objectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+    value.objectId = {type: decodedValue.objectType, instance: decodedValue.instance};
     result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
     len += result.len;
     decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
@@ -1796,8 +1801,8 @@ module.exports.decodeEventInformation = function(buffer, offset, apduLen) {
   };
 };
 
-module.exports.encodePrivateTransfer = function(buffer, vendorID, serviceNumber, data) {
-  baAsn1.encodeContextUnsigned(buffer, 0, vendorID);
+module.exports.encodePrivateTransfer = function(buffer, vendorId, serviceNumber, data) {
+  baAsn1.encodeContextUnsigned(buffer, 0, vendorId);
   baAsn1.encodeContextUnsigned(buffer, 1, serviceNumber);
   baAsn1.encodeOpeningTag(buffer, 2);
   for (var i = 0; i < data.length; i++) {
@@ -1815,7 +1820,7 @@ module.exports.decodePrivateTransfer = function(buffer, offset, apduLen) {
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
   len += decodedValue.len;
-  value.vendorID = decodedValue.value;
+  value.vendorId = decodedValue.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeUnsigned(buffer, offset + len, result.value);
@@ -1835,8 +1840,8 @@ module.exports.decodePrivateTransfer = function(buffer, offset, apduLen) {
   return value;
 };
 
-module.exports.encodeGetEventInformation = function(buffer, lastReceivedObjectIdentifier) {
-  baAsn1.encodeContextObjectId(buffer, 0, lastReceivedObjectIdentifier.type, lastReceivedObjectIdentifier.instance);
+module.exports.encodeGetEventInformation = function(buffer, lastReceivedObjectId) {
+  baAsn1.encodeContextObjectId(buffer, 0, lastReceivedObjectId.type, lastReceivedObjectId.instance);
 };
 
 module.exports.decodeGetEventInformation = function(buffer, offset) {
@@ -1848,7 +1853,7 @@ module.exports.decodeGetEventInformation = function(buffer, offset) {
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  value.lastReceivedObjectIdentifier = {type: decodedValue.objectType, instance: decodedValue.instance};
+  value.lastReceivedObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   value.len = len;
   return value;
 };
@@ -1883,11 +1888,11 @@ module.exports.decodeIhaveBroadcast = function(buffer, offset, apduLen) {
   return value;
 };
 
-module.exports.encodeLifeSafetyOperation = function(buffer, processId, requestingSrc, operation, targetObject) {
+module.exports.encodeLifeSafetyOperation = function(buffer, processId, requestingSource, operation, targetObjectId) {
   baAsn1.encodeContextUnsigned(buffer, 0, processId);
-  baAsn1.encodeContextCharacterString(buffer, 1, requestingSrc);
+  baAsn1.encodeContextCharacterString(buffer, 1, requestingSource);
   baAsn1.encodeContextEnumerated(buffer, 2, operation);
-  baAsn1.encodeContextObjectId(buffer, 3, targetObject.type, targetObject.instance);
+  baAsn1.encodeContextObjectId(buffer, 3, targetObjectId.type, targetObjectId.instance);
 };
 
 module.exports.decodeLifeSafetyOperation = function(buffer, offset, apduLen) {
@@ -1904,7 +1909,7 @@ module.exports.decodeLifeSafetyOperation = function(buffer, offset, apduLen) {
   len += result.len;
   decodedValue = baAsn1.decodeCharacterString(buffer, offset + len, apduLen - (offset + len), result.value);
   len += decodedValue.len;
-  value.requestingSrc = decodedValue.value;
+  value.requestingSource = decodedValue.value;
   result = baAsn1.decodeTagNumberAndValue(buffer, offset + len);
   len += result.len;
   decodedValue = baAsn1.decodeEnumerated(buffer, offset + len, result.value);
@@ -1914,20 +1919,20 @@ module.exports.decodeLifeSafetyOperation = function(buffer, offset, apduLen) {
   len += result.len;
   decodedValue = baAsn1.decodeObjectId(buffer, offset + len);
   len += decodedValue.len;
-  value.targetObject = {type: decodedValue.objectType, instance: decodedValue.instance};
+  value.targetObjectId = {type: decodedValue.objectType, instance: decodedValue.instance};
   value.len = len;
   return value;
 };
 
 // TODO: Implement decoding for following functions
-module.exports.encodeAddListElement = function(buffer, objectId, propertyId, arrayIndex, valueList) {
+module.exports.encodeAddListElement = function(buffer, objectId, propertyId, arrayIndex, values) {
   baAsn1.encodeContextObjectId(buffer, 0, objectId.type, objectId.instance);
   baAsn1.encodeContextEnumerated(buffer, 1, propertyId);
   if (arrayIndex !== baAsn1.BACNET_ARRAY_ALL) {
     baAsn1.encodeContextUnsigned(buffer, 2, arrayIndex);
   }
   baAsn1.encodeOpeningTag(buffer, 3);
-  valueList.forEach(function(value) {
+  values.forEach(function(value) {
     baAsn1.bacappEncodeApplicationData(buffer, value);
   });
   baAsn1.encodeClosingTag(buffer, 3);
@@ -1937,7 +1942,7 @@ module.exports.encodeGetEventInformationAcknowledge = function(buffer, events, m
   var i;
   baAsn1.encodeOpeningTag(buffer, 0);
   events.forEach(function(eventData) {
-    baAsn1.encodeContextObjectId(buffer, 0, eventData.objectIdentifier.type, eventData.objectIdentifier.instance);
+    baAsn1.encodeContextObjectId(buffer, 0, eventData.objectId.type, eventData.objectId.instance);
     baAsn1.encodeContextEnumerated(buffer, 1, eventData.eventState);
     baAsn1.encodeContextBitstring(buffer, 2, eventData.acknowledgedTransitions);
     baAsn1.encodeOpeningTag(buffer, 3);

--- a/test/integration/add-list-element.spec.js
+++ b/test/integration/add-list-element.spec.js
@@ -4,7 +4,7 @@ var utils = require('./utils');
 describe('bacstack - addListElement integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.addListElement('127.0.0.1', {type: 19, instance: 101}, {propertyIdentifier: 80, propertyArrayIndex: 0}, [
+    client.addListElement('127.0.0.1', {type: 19, instance: 101}, {id: 80, index: 0}, [
       {type: 1, value: true}
     ], function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');

--- a/test/integration/create-object.spec.js
+++ b/test/integration/create-object.spec.js
@@ -5,7 +5,7 @@ describe('bacstack - createObject integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
     client.createObject('127.0.0.1', {type: 2, instance: 300}, [
-      {property: {propertyIdentifier: 85, propertyArrayIndex: 1}, value: [{type: 1, value: true}]}
+      {property: {id: 85, index: 1}, value: [{type: 1, value: true}]}
     ], function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');
       expect(value).to.eql(undefined);

--- a/test/integration/read-property-multiple.spec.js
+++ b/test/integration/read-property-multiple.spec.js
@@ -5,7 +5,7 @@ describe('bacstack - readPropertyMultiple integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
     var requestArray = [
-      {objectIdentifier: {type: 8, instance: 4194303}, propertyReferences: [{propertyIdentifier: 8}]}
+      {objectId: {type: 8, instance: 4194303}, properties: [{id: 8}]}
     ];
     client.readPropertyMultiple('127.0.0.1', requestArray, function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');
@@ -20,12 +20,12 @@ describe('bacstack - readPropertyMultiple integration', function() {
     var client = utils.bacnetClient({transport: transport});
     var data = Buffer.from('810a0109010030000e0c0740001f1e291c4e752900436f6c6c656374696f6e206f66206c69676874696e672070726573656e6365206465746563746f724f294b4ec40740001f4f294d4e7531005ac3a4686c657277656727466c6f6f72203427525365675456274c6774275073634f70274c6774507363446574436f6c4f294f4e911d4f29a84e751800372d42412d524453312d3034312d5342437631332e32304f29cf4e71004f29d04e91084f29d24e750c004c67745073634465745273750a00507363446574282a294f29d34e1c014000001c00c000004f2a13424e91004f2a134d4e91064f2a13a64e21004f2a13bd4e91004f2a13de4e8207808207004f2a13ee4e91294f1f', 'hex');  // jscs:ignore maximumLineLength
     var requestArray = [
-      {objectIdentifier: {type: 8, instance: 4194303}, propertyReferences: [{propertyIdentifier: 8}]}
+      {objectId: {type: 8, instance: 4194303}, properties: [{id: 8}]}
     ];
     client.readPropertyMultiple('127.0.0.1', requestArray, function(err, response) {
       expect(err).to.equal(null);
       var object = utils.propertyFormater(response.values[0].values);
-      expect(response.values[0].objectIdentifier).to.deep.equal({type: 29, instance: 31});
+      expect(response.values[0].objectId).to.deep.equal({type: 29, instance: 31});
       expect(object[28]).to.deep.equal([{value: 'Collection of lighting presence detector', type: 7, encoding: 0}]);
       expect(object[75]).to.deep.equal([{value: {type: 29, instance: 31}, type: 12}]);
       expect(object[77]).to.deep.equal([{value: 'Zählerweg\'Floor 4\'RSegTV\'Lgt\'PscOp\'LgtPscDetCol', type: 7, encoding: 0}]);
@@ -61,11 +61,11 @@ describe('bacstack - readPropertyMultiple integration', function() {
     var client = utils.bacnetClient({transport: transport});
     var data = Buffer.from('810a01eb010030000e0c04c0000a1e291c4e75070053656e736f724f29244e91004f294a4e21084f294b4ec404c0000a4f294d4e7525005ac3a4686c657277656727466c6f6f722034275253656754562753656e4465762753656e4f294f4e91134f29514e104f29554e21014f29674e91004f296e4e750c004f7065726174696f6e616c750f004465766963652073746f70706564751400446576696365206e6f742061737369676e6564750f00446576696365206d697373696e67751300436f6e6669677572696e6720646576696365750700556e75736564751f004d697373696e67206f722077726f6e6720636f6e66696775726174696f6e750a00536561726368696e674f296f4e8204004f29a84e751800372d42412d524453312d3032342d5342437631332e32304f2a13424e91004f2a134d4e91054f2a13884e91004f2a13894e91004f2a13af4e750800302e322e3234394f2a13df4e750e00355747313235382d32444231324f2a13e44e750b00504c2d313a444c3d313b4f2a13e64e21034f2a13ec4e750d003030303130303433656464634f2a13ed4e752d00504c3a4444543d303538362e303030312e30302e30312e30303b46573d302e312e31333b4d4f44453d504c3b4f2a13ee4e91184f2a13ef4e71004f2a13f04e91004f2a13f34e21014f1f', 'hex');  // jscs:ignore maximumLineLength
     var requestArray = [
-      {objectIdentifier: {type: 8, instance: 4194303}, propertyReferences: [{propertyIdentifier: 8}]}
+      {objectId: {type: 8, instance: 4194303}, properties: [{id: 8}]}
     ];
     client.readPropertyMultiple('127.0.0.1', requestArray, function(err, response) {
       expect(err).to.equal(null);
-      expect(response.values[0].objectIdentifier).to.deep.equal({type: 19, instance: 10});
+      expect(response.values[0].objectId).to.deep.equal({type: 19, instance: 10});
       var object = utils.propertyFormater(response.values[0].values);
       expect(object[28]).to.deep.equal([{value: 'Sensor', type: 7, encoding: 0}]);
       expect(object[36]).to.deep.equal([{value: 0, type: 9}]);

--- a/test/integration/remove-list-element.spec.js
+++ b/test/integration/remove-list-element.spec.js
@@ -4,7 +4,7 @@ var utils = require('./utils');
 describe('bacstack - removeListElement integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.removeListElement('127.0.0.1', {type: 19, instance: 100}, {propertyIdentifier: 80, propertyArrayIndex: 0}, [
+    client.removeListElement('127.0.0.1', {type: 19, instance: 100}, {id: 80, index: 0}, [
       {type: 1, value: true}
     ], function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');

--- a/test/integration/subscribe-property.spec.js
+++ b/test/integration/subscribe-property.spec.js
@@ -4,7 +4,7 @@ var utils = require('./utils');
 describe('bacstack - subscribeProperty integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.subscribeProperty('127.0.0.1', {type: 5, instance: 33}, {propertyIdentifier: 80, propertyArrayIndex: 0}, 8, false, false, function(err, value) {
+    client.subscribeProperty('127.0.0.1', {type: 5, instance: 33}, {id: 80, index: 0}, 8, false, false, function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');
       expect(value).to.eql(undefined);
       client.close();

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -24,7 +24,7 @@ module.exports.transportStub = function() {
 module.exports.propertyFormater = function(object) {
   var converted = {};
   object.forEach(function(property) {
-    converted[property.propertyIdentifier] = property.value;
+    converted[property.id] = property.value;
   });
   return converted;
 };

--- a/test/integration/write-property-multiple.spec.js
+++ b/test/integration/write-property-multiple.spec.js
@@ -4,12 +4,12 @@ var utils = require('./utils');
 describe('bacstack - writePropertyMultiple integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    var valueList = [
-      {objectIdentifier: {type: 8, instance: 44301}, values: [
-        {property: {propertyIdentifier: 28, propertyArrayIndex: 12}, value: [{type: 1, value: true}], priority: 8}
+    var values = [
+      {objectId: {type: 8, instance: 44301}, values: [
+        {property: {id: 28, index: 12}, value: [{type: 1, value: true}], priority: 8}
       ]}
     ];
-    client.writePropertyMultiple('127.0.0.1', valueList, function(err, value) {
+    client.writePropertyMultiple('127.0.0.1', values, function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');
       expect(value).to.eql(undefined);
       client.close();

--- a/test/unit/bacnet-services.spec.js
+++ b/test/unit/bacnet-services.spec.js
@@ -28,7 +28,7 @@ describe('bacstack - Services layer', function() {
       expect(result).to.deep.equal({
         lowLimit: 3,
         highLimit: 4000,
-        objId: {
+        objectId: {
           type: 3,
           instance: 15
         }
@@ -43,7 +43,7 @@ describe('bacstack - Services layer', function() {
       expect(result).to.deep.equal({
         lowLimit: 3,
         highLimit: 4000,
-        objName: 'analog-output-1'
+        objectName: 'analog-output-1'
       });
     });
   });
@@ -76,12 +76,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 1, value: true, len: 1},
-          {type: 1, value: false, len: 1}
+        values: [
+          {type: 1, value: true},
+          {type: 1, value: false}
         ]
       });
     });
@@ -99,11 +99,11 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 2,
-          propertyIdentifier: 81
+          index: 2,
+          id: 81
         },
-        valueList: [
-          {type: 1, value: true, len: 1}
+        values: [
+          {type: 1, value: true}
         ]
       });
     });
@@ -124,14 +124,14 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 2, value: 1, len: 2},
-          {type: 2, value: 1000, len: 3},
-          {type: 2, value: 1000000, len: 4},
-          {type: 2, value: 1000000000, len: 5}
+        values: [
+          {type: 2, value: 1},
+          {type: 2, value: 1000},
+          {type: 2, value: 1000000},
+          {type: 2, value: 1000000000}
         ]
       });
     });
@@ -152,14 +152,14 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 3, value: -1, len: 2},
-          {type: 3, value: -1000, len: 3},
-          {type: 3, value: -1000000, len: 4},
-          {type: 3, value: -1000000000, len: 5}
+        values: [
+          {type: 3, value: -1},
+          {type: 3, value: -1000},
+          {type: 3, value: -1000000},
+          {type: 3, value: -1000000000}
         ]
       });
     });
@@ -172,20 +172,20 @@ describe('bacstack - Services layer', function() {
       ]);
       var result = baServices.decodeReadPropertyAcknowledge(buffer.buffer, 0, buffer.offset);
       delete result.len;
-      expect(Math.floor(0.1 * 10000)).to.equal(Math.floor(result.valueList[1].value * 10000));
-      result.valueList[1].value = 0;
+      expect(Math.floor(0.1 * 10000)).to.equal(Math.floor(result.values[1].value * 10000));
+      result.values[1].value = 0;
       expect(result).to.deep.equal({
         objectId: {
           type: 8,
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 4, value: 0, len: 5},
-          {type: 4, value: 0, len: 5}
+        values: [
+          {type: 4, value: 0},
+          {type: 4, value: 0}
         ]
       });
     });
@@ -204,12 +204,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 5, value: 0, len: 10},
-          {type: 5, value: 100.121212, len: 10}
+        values: [
+          {type: 5, value: 0},
+          {type: 5, value: 100.121212}
         ]
       });
     });
@@ -228,12 +228,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 6, value: [], len: 1},
-          {type: 6, value: [1, 2, 100, 200], len: 5}
+        values: [
+          {type: 6, value: []},
+          {type: 6, value: [1, 2, 100, 200]}
         ]
       });
     });
@@ -252,12 +252,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 7, value: '', encoding: 0, len: 2},
-          {type: 7, value: 'Test1234$äöü', encoding: 0, len: 18}
+        values: [
+          {type: 7, value: '', encoding: 0},
+          {type: 7, value: 'Test1234$äöü', encoding: 0}
         ]
       });
     });
@@ -276,12 +276,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_ISO8859_1, len: 2},
-          {type: 7, value: 'Test1234$äöü', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_ISO8859_1, len: 15}
+        values: [
+          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_ISO8859_1},
+          {type: 7, value: 'Test1234$äöü', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_ISO8859_1}
         ]
       });
     });
@@ -300,12 +300,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_UCS2, len: 2},
-          {type: 7, value: 'Test1234$äöü', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_UCS2, len: 27}
+        values: [
+          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_UCS2},
+          {type: 7, value: 'Test1234$äöü', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_UCS2}
         ]
       });
     });
@@ -324,12 +324,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_MS_DBCS, len: 2},
-          {type: 7, value: 'Test1234$äöü', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_MS_DBCS, len: 15}
+        values: [
+          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_MS_DBCS},
+          {type: 7, value: 'Test1234$äöü', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_MS_DBCS}
         ]
       });
     });
@@ -348,12 +348,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_JISX_0208, len: 2},
-          {type: 7, value: 'できます', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_JISX_0208, len: 11}
+        values: [
+          {type: 7, value: '', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_JISX_0208},
+          {type: 7, value: 'できます', encoding: baEnum.BacnetCharacterStringEncodings.CHARACTER_JISX_0208}
         ]
       });
     });
@@ -372,12 +372,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 8, value: {bitsUsed: 0, value: []}, len: 2},
-          {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}, len: 5}
+        values: [
+          {type: 8, value: {bitsUsed: 0, value: []}},
+          {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}}
         ]
       });
     });
@@ -396,12 +396,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 9, value: 0, len: 2},
-          {type: 9, value: 4, len: 2}
+        values: [
+          {type: 9, value: 0},
+          {type: 9, value: 4}
         ]
       });
     });
@@ -420,11 +420,11 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 10, value: date, len: 5}
+        values: [
+          {type: 10, value: date}
         ]
       });
     });
@@ -444,11 +444,11 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 11, value: time, len: 5}
+        values: [
+          {type: 11, value: time}
         ]
       });
     });
@@ -467,12 +467,12 @@ describe('bacstack - Services layer', function() {
           instance: 40000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 81
+          index: 0xFFFFFFFF,
+          id: 81
         },
-        valueList: [
-          {type: 12, value: {type: 3, instance: 0}, len: 5},
-          {type: 12, value: {type: 3, instance: 50000}, len: 5}
+        values: [
+          {type: 12, value: {type: 3, instance: 0}},
+          {type: 12, value: {type: 3, instance: 50000}}
         ]
       });
     });
@@ -481,21 +481,21 @@ describe('bacstack - Services layer', function() {
       var buffer = utils.getBuffer();
       baServices.encodeReadPropertyAcknowledge(buffer, {type: 222, instance: 3}, 152, 0xFFFFFFFF, [
         {type: 111, value: {
-          Recipient: {net: 12, adr: [0, 1]},
-          subscriptionProcessIdentifier: 3,
-          monitoredObjectIdentifier: {type: 2, instance: 1},
-          monitoredProperty: {propertyIdentifier: 85, propertyArrayIndex: 0},
-          IssueConfirmedNotifications: false,
-          TimeRemaining: 5,
-          COVIncrement: 1
+          recipient: {network: 12, address: [0, 1]},
+          subscriptionProcessId: 3,
+          monitoredObjectId: {type: 2, instance: 1},
+          monitoredProperty: {id: 85, index: 0},
+          issueConfirmedNotifications: false,
+          timeRemaining: 5,
+          covIncrement: 1
         }},
         {type: 111, value: {
-          Recipient: {net: 0xFFFF, adr: []},
-          subscriptionProcessIdentifier: 3,
-          monitoredObjectIdentifier: {type: 2, instance: 1},
-          monitoredProperty: {propertyIdentifier: 85, propertyArrayIndex: 5},
-          IssueConfirmedNotifications: true,
-          TimeRemaining: 5
+          recipient: {network: 0xFFFF, address: []},
+          subscriptionProcessId: 3,
+          monitoredObjectId: {type: 2, instance: 1},
+          monitoredProperty: {id: 85, index: 5},
+          issueConfirmedNotifications: true,
+          timeRemaining: 5
         }}
       ]);
       var result = baServices.decodeReadPropertyAcknowledge(buffer.buffer, 0, buffer.offset);
@@ -506,27 +506,27 @@ describe('bacstack - Services layer', function() {
           instance: 3
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 152
+          index: 0xFFFFFFFF,
+          id: 152
         },
-        valueList: [
+        values: [
           {type: 111, value: {
             recipient: {net: 12, adr: [0, 1]},
-            subscriptionProcessIdentifier: 3,
-            monitoredObjectIdentifier: {type: 2, instance: 1},
-            monitoredProperty: {propertyIdentifier: 85, propertyArrayIndex: 0},
+            subscriptionProcessId: 3,
+            monitoredObjectId: {type: 2, instance: 1},
+            monitoredProperty: {id: 85, index: 0},
             issueConfirmedNotifications: false,
             timeRemaining: 5,
             covIncrement: 1
-          }, len: 33},
+          }},
           {type: 111, value: {
             recipient: {net: 0xFFFF, adr: []},
-            subscriptionProcessIdentifier: 3,
-            monitoredObjectIdentifier: {type: 2, instance: 1},
-            monitoredProperty: {propertyIdentifier: 85, propertyArrayIndex: 5},
+            subscriptionProcessId: 3,
+            monitoredObjectId: {type: 2, instance: 1},
+            monitoredProperty: {id: 85, index: 5},
             issueConfirmedNotifications: true,
             timeRemaining: 5
-          }, len: 27}
+          }}
         ]
       });
     });
@@ -534,10 +534,10 @@ describe('bacstack - Services layer', function() {
     it('should successfully encode and decode a read-access-specification value', function() {
       var buffer = utils.getBuffer();
       baServices.encodeReadPropertyAcknowledge(buffer, {type: 223, instance: 90000}, 53, 0xFFFFFFFF, [
-        {type: 115, value: {objectIdentifier: {type: 3, instance: 0}, propertyReferences: []}},
-        {type: 115, value: {objectIdentifier: {type: 3, instance: 50000}, propertyReferences: [
-          {propertyIdentifier: 85},
-          {propertyIdentifier: 1, propertyArrayIndex: 2}
+        {type: 115, value: {objectId: {type: 3, instance: 0}, properties: []}},
+        {type: 115, value: {objectId: {type: 3, instance: 50000}, properties: [
+          {id: 85},
+          {id: 1, index: 2}
         ]}}
       ]);
       var result = baServices.decodeReadPropertyAcknowledge(buffer.buffer, 0, buffer.offset);
@@ -548,15 +548,15 @@ describe('bacstack - Services layer', function() {
           instance: 90000
         },
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 53
+          index: 0xFFFFFFFF,
+          id: 53
         },
-        valueList: [
-          {type: 115, value: {objectIdentifier: {type: 3, instance: 0}, propertyReferences: []}, len: 7},
-          {type: 115, value: {objectIdentifier: {type: 3, instance: 50000}, propertyReferences: [
-            {propertyIdentifier: 85, propertyArrayIndex: 0xFFFFFFFF},
-            {propertyIdentifier: 1, propertyArrayIndex: 2}
-          ]}, len: 13}
+        values: [
+          {type: 115, value: {objectId: {type: 3, instance: 0}, properties: []}},
+          {type: 115, value: {objectId: {type: 3, instance: 50000}, properties: [
+            {id: 85, index: 0xFFFFFFFF},
+            {id: 1, index: 2}
+          ]}}
         ]
       });
     });
@@ -569,8 +569,8 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeReadPropertyMultipleAcknowledge(buffer, [
-        {objectIdentifier: {type: 9, instance: 50000}, values: [
-          {property: {propertyIdentifier: 81, propertyArrayIndex: 0xFFFFFFFF}, value: [
+        {objectId: {type: 9, instance: 50000}, values: [
+          {property: {id: 81, index: 0xFFFFFFFF}, value: [
             {type: 0},
             {type: 1, value: null},
             {type: 1, value: true},
@@ -602,13 +602,13 @@ describe('bacstack - Services layer', function() {
       result.values[0].values[0].value[12].value = 0;
       expect(result).to.deep.equal({
         values: [{
-          objectIdentifier: {
+          objectId: {
             type: 9,
             instance: 50000
           },
           values: [{
-            propertyArrayIndex: 4294967295,
-            propertyIdentifier: 81,
+            index: 4294967295,
+            id: 81,
             value: [
               {type: 0, value: null},
               {type: 0, value: null},
@@ -676,29 +676,29 @@ describe('bacstack - Services layer', function() {
         value: {
           priority: 16,
           property: {
-            propertyArrayIndex: 4294967295,
-            propertyIdentifier: 80
+            index: 4294967295,
+            id: 80
           },
           value: [
-            null,
-            null,
-            true,
-            false,
-            1,
-            1000,
-            1000000,
-            1000000000,
-            -1,
-            -1000,
-            -1000000,
-            -1000000000,
-            0,
-            100.121212,
-            'Test1234$',
-            4,
-            date,
-            time,
-            {instance: 0, type: 3}
+            {type: 0, value: null},
+            {type: 0, value: null},
+            {type: 1, value: true},
+            {type: 1, value: false},
+            {type: 2, value: 1},
+            {type: 2, value: 1000},
+            {type: 2, value: 1000000},
+            {type: 2, value: 1000000000},
+            {type: 3, value: -1},
+            {type: 3, value: -1000},
+            {type: 3, value: -1000000},
+            {type: 3, value: -1000000000},
+            {type: 4, value: 0},
+            {type: 5, value: 100.121212},
+            {type: 7, value: 'Test1234$', encoding: 0},
+            {type: 9, value: 4},
+            {type: 10, value: date},
+            {type: 11, value: time},
+            {type: 12, value: {type: 3, instance: 0}}
           ]
         }
       });
@@ -740,29 +740,29 @@ describe('bacstack - Services layer', function() {
         value: {
           priority: 8,
           property: {
-            propertyArrayIndex: 4294967295,
-            propertyIdentifier: 80
+            index: 4294967295,
+            id: 80
           },
           value: [
-            null,
-            null,
-            true,
-            false,
-            1,
-            1000,
-            1000000,
-            1000000000,
-            -1,
-            -1000,
-            -1000000,
-            -1000000000,
-            0,
-            100.121212,
-            'Test1234$',
-            4,
-            date,
-            time,
-            {instance: 0, type: 3}
+            {type: 0, value: null},
+            {type: 0, value: null},
+            {type: 1, value: true},
+            {type: 1, value: false},
+            {type: 2, value: 1},
+            {type: 2, value: 1000},
+            {type: 2, value: 1000000},
+            {type: 2, value: 1000000000},
+            {type: 3, value: -1},
+            {type: 3, value: -1000},
+            {type: 3, value: -1000000},
+            {type: 3, value: -1000000000},
+            {type: 4, value: 0},
+            {type: 5, value: 100.121212},
+            {type: 7, value: 'Test1234$', encoding: 0},
+            {type: 9, value: 4},
+            {type: 10, value: date},
+            {type: 11, value: time},
+            {type: 12, value: {type: 3, instance: 0}}
           ]
         }
       });
@@ -774,8 +774,8 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeWriteProperty(buffer, 31, 12, 80, 2, 0, [
-        {type: 0},
-        {type: 1, value: null},
+        {type: 0, value: null},
+        {type: 0, value: null},
         {type: 1, value: true},
         {type: 1, value: false},
         {type: 2, value: 1},
@@ -788,7 +788,7 @@ describe('bacstack - Services layer', function() {
         {type: 3, value: -1000000000},
         {type: 4, value: 0},
         {type: 5, value: 100.121212},
-        {type: 7, value: 'Test1234$'},
+        {type: 7, value: 'Test1234$', encoding: 0},
         {type: 9, value: 4},
         {type: 10, value: date},
         {type: 11, value: time},
@@ -804,29 +804,29 @@ describe('bacstack - Services layer', function() {
         value: {
           priority: 16,
           property: {
-            propertyArrayIndex: 2,
-            propertyIdentifier: 80
+            index: 2,
+            id: 80
           },
           value: [
-            null,
-            null,
-            true,
-            false,
-            1,
-            1000,
-            1000000,
-            1000000000,
-            -1,
-            -1000,
-            -1000000,
-            -1000000000,
-            0,
-            100.121212,
-            'Test1234$',
-            4,
-            date,
-            time,
-            {instance: 0, type: 3}
+            {type: 0, value: null},
+            {type: 0, value: null},
+            {type: 1, value: true},
+            {type: 1, value: false},
+            {type: 2, value: 1},
+            {type: 2, value: 1000},
+            {type: 2, value: 1000000},
+            {type: 2, value: 1000000000},
+            {type: 3, value: -1},
+            {type: 3, value: -1000},
+            {type: 3, value: -1000000},
+            {type: 3, value: -1000000000},
+            {type: 4, value: 0},
+            {type: 5, value: 100.121212},
+            {type: 7, value: 'Test1234$', encoding: 0},
+            {type: 9, value: 4},
+            {type: 10, value: date},
+            {type: 11, value: time},
+            {type: 12, value: {type: 3, instance: 0}}
           ]
         }
       });
@@ -840,9 +840,9 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeWritePropertyMultiple(buffer, {type: 39, instance: 2400}, [
-        {property: {propertyIdentifier: 81, propertyArrayIndex: 0xFFFFFFFF}, value: [
-          {type: 0},
-          {type: 1, value: null},
+        {property: {id: 81, index: 0xFFFFFFFF}, value: [
+          {type: 0, value: null},
+          {type: 0, value: null},
           {type: 1, value: true},
           {type: 1, value: false},
           {type: 2, value: 1},
@@ -867,42 +867,42 @@ describe('bacstack - Services layer', function() {
       ]);
       var result = baServices.decodeWritePropertyMultiple(buffer.buffer, 0, buffer.offset);
       delete result.len;
-      result.valuesRefs[0].value[12].value = Math.floor(result.valuesRefs[0].value[12].value * 1000) / 1000;
+      result.values[0].value[12].value = Math.floor(result.values[0].value[12].value * 1000) / 1000;
       expect(result).to.deep.equal({
         objectId: {
           type: 39,
           instance: 2400
         },
-        valuesRefs: [
+        values: [
           {
             priority: 0,
             property: {
-              arrayIndex: 0xFFFFFFFF,
-              propertyId: 81
+              index: 0xFFFFFFFF,
+              id: 81
             },
             value: [
-              {type: 0, value: null, len: 1},
-              {type: 0, value: null, len: 1},
-              {type: 1, value: true, len: 1},
-              {type: 1, value: false, len: 1},
-              {type: 2, value: 1, len: 2},
-              {type: 2, value: 1000, len: 3},
-              {type: 2, value: 1000000, len: 4},
-              {type: 2, value: 1000000000, len: 5},
-              {type: 3, value: -1, len: 2},
-              {type: 3, value: -1000, len: 3},
-              {type: 3, value: -1000000, len: 4},
-              {type: 3, value: -1000000000, len: 5},
-              {type: 4, value: 0.1, len: 5},
-              {type: 5, value: 100.121212, len: 10},
-              {type: 6, value: [1, 2, 100, 200], len: 5},
-              {type: 7, value: 'Test1234$', encoding: 0, len: 12},
-              {type: 8, value: {bitsUsed: 0, value: []}, len: 2},
-              {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}, len: 5},
-              {type: 9, value: 4, len: 2},
-              {type: 10, value: date, len: 5},
-              {type: 11, value: time, len: 5},
-              {type: 12, value: {type: 3, instance: 0}, len: 5}
+              {type: 0, value: null},
+              {type: 0, value: null},
+              {type: 1, value: true},
+              {type: 1, value: false},
+              {type: 2, value: 1},
+              {type: 2, value: 1000},
+              {type: 2, value: 1000000},
+              {type: 2, value: 1000000000},
+              {type: 3, value: -1},
+              {type: 3, value: -1000},
+              {type: 3, value: -1000000},
+              {type: 3, value: -1000000000},
+              {type: 4, value: 0.1},
+              {type: 5, value: 100.121212},
+              {type: 6, value: [1, 2, 100, 200]},
+              {type: 7, value: 'Test1234$', encoding: 0},
+              {type: 8, value: {bitsUsed: 0, value: []}},
+              {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}},
+              {type: 9, value: 4},
+              {type: 10, value: date},
+              {type: 11, value: time},
+              {type: 12, value: {type: 3, instance: 0}}
             ]
           }
         ]
@@ -915,7 +915,7 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeWritePropertyMultiple(buffer, {type: 39, instance: 2400}, [
-        {property: {propertyIdentifier: 81, propertyArrayIndex: 0xFFFFFFFF}, value: [
+        {property: {id: 81, index: 0xFFFFFFFF}, value: [
           {type: 7, value: 'Test1234$'}
         ], priority: 12}
       ]);
@@ -926,15 +926,15 @@ describe('bacstack - Services layer', function() {
           type: 39,
           instance: 2400
         },
-        valuesRefs: [
+        values: [
           {
             priority: 12,
             property: {
-              arrayIndex: 0xFFFFFFFF,
-              propertyId: 81
+              index: 0xFFFFFFFF,
+              id: 81
             },
             value: [
-              {type: 7, value: 'Test1234$', encoding: 0, len: 12}
+              {type: 7, value: 'Test1234$', encoding: 0}
             ]
           }
         ]
@@ -947,7 +947,7 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeWritePropertyMultiple(buffer, {type: 39, instance: 2400}, [
-        {property: {propertyIdentifier: 81, propertyArrayIndex: 414141}, value: [
+        {property: {id: 81, index: 414141}, value: [
           {type: 7, value: 'Test1234$'}
         ], priority: 0}
       ]);
@@ -958,15 +958,15 @@ describe('bacstack - Services layer', function() {
           type: 39,
           instance: 2400
         },
-        valuesRefs: [
+        values: [
           {
             priority: 0,
             property: {
-              arrayIndex: 414141,
-              propertyId: 81
+              index: 414141,
+              id: 81
             },
             value: [
-              {type: 7, value: 'Test1234$', encoding: 0, len: 12}
+              {type: 7, value: 'Test1234$', encoding: 0}
             ]
           }
         ]
@@ -1053,16 +1053,16 @@ describe('bacstack - Services layer', function() {
     it('should successfully encode and decode', function() {
       var buffer = utils.getBuffer();
       baServices.encodeReadPropertyMultiple(buffer, [
-        {objectIdentifier: {type: 51, instance: 1}, propertyReferences: [
-          {propertyIdentifier: 85, propertyArrayIndex: 0xFFFFFFFF},
-          {propertyIdentifier: 85, propertyArrayIndex: 4}
+        {objectId: {type: 51, instance: 1}, properties: [
+          {id: 85, index: 0xFFFFFFFF},
+          {id: 85, index: 4}
         ]}
       ]);
       var result = baServices.decodeReadPropertyMultiple(buffer.buffer, 0, buffer.offset);
       delete result.len;
-      expect(result).to.deep.equal({properties: [{objectIdentifier: {type: 51, instance: 1}, propertyReferences: [
-        {propertyIdentifier: 85, propertyArrayIndex: 0xFFFFFFFF},
-        {propertyIdentifier: 85, propertyArrayIndex: 4}
+      expect(result).to.deep.equal({properties: [{objectId: {type: 51, instance: 1}, properties: [
+        {id: 85, index: 0xFFFFFFFF},
+        {id: 85, index: 4}
       ]}]});
     });
   });
@@ -1070,7 +1070,7 @@ describe('bacstack - Services layer', function() {
   describe('SubscribeProperty', function() {
     it('should successfully encode and decode with cancellation request', function() {
       var buffer = utils.getBuffer();
-      baServices.encodeSubscribeProperty(buffer, 7, {type: 148, instance: 362}, true, false, 1, {propertyIdentifier: 85, propertyArrayIndex: 0xFFFFFFFF}, true, 1);
+      baServices.encodeSubscribeProperty(buffer, 7, {type: 148, instance: 362}, true, false, 1, {id: 85, index: 0xFFFFFFFF}, true, 1);
       var result = baServices.decodeSubscribeProperty(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
@@ -1078,21 +1078,21 @@ describe('bacstack - Services layer', function() {
         covIncrement: 1,
         issueConfirmedNotifications: false,
         lifetime: 0,
-        monitoredObjectIdentifier: {
+        monitoredObjectId: {
           instance: 362,
           type: 148
         },
         monitoredProperty: {
-          propertyArrayIndex: 4294967295,
-          propertyIdentifier: 85
+          index: 4294967295,
+          id: 85
         },
-        subscriberProcessIdentifier: 7
+        subscriberProcessId: 7
       });
     });
 
     it('should successfully encode and decode without cancellation request', function() {
       var buffer = utils.getBuffer();
-      baServices.encodeSubscribeProperty(buffer, 8, {type: 149, instance: 363}, false, true, 2, {propertyIdentifier: 86, propertyArrayIndex: 3}, false, 10);
+      baServices.encodeSubscribeProperty(buffer, 8, {type: 149, instance: 363}, false, true, 2, {id: 86, index: 3}, false, 10);
       var result = baServices.decodeSubscribeProperty(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
@@ -1100,15 +1100,15 @@ describe('bacstack - Services layer', function() {
         covIncrement: 0,
         issueConfirmedNotifications: true,
         lifetime: 2,
-        monitoredObjectIdentifier: {
+        monitoredObjectId: {
           instance: 363,
           type: 149
         },
         monitoredProperty: {
-          propertyArrayIndex: 3,
-          propertyIdentifier: 86
+          index: 3,
+          id: 86
         },
-        subscriberProcessIdentifier: 8
+        subscriberProcessId: 8
       });
     });
   });
@@ -1121,8 +1121,8 @@ describe('bacstack - Services layer', function() {
       delete result.len;
       expect(result).to.deep.equal({
         cancellationRequest: true,
-        monitoredObjectIdentifier: {type: 3, instance: 1},
-        subscriberProcessIdentifier: 10
+        monitoredObjectId: {type: 3, instance: 1},
+        subscriberProcessId: 10
       });
     });
 
@@ -1135,8 +1135,8 @@ describe('bacstack - Services layer', function() {
         cancellationRequest: false,
         issueConfirmedNotifications: true,
         lifetime: 5000,
-        monitoredObjectIdentifier: {type: 3, instance: 2},
-        subscriberProcessIdentifier: 11
+        monitoredObjectId: {type: 3, instance: 2},
+        subscriberProcessId: 11
       });
     });
   });
@@ -1173,7 +1173,7 @@ describe('bacstack - Services layer', function() {
       delete result.len;
       expect(result).to.deep.equal({
         objectId: {type: 4, instance: 630},
-        property: {propertyIdentifier: 85, propertyArrayIndex: 0xFFFFFFFF}
+        property: {id: 85, index: 0xFFFFFFFF}
       });
     });
 
@@ -1184,7 +1184,7 @@ describe('bacstack - Services layer', function() {
       delete result.len;
       expect(result).to.deep.equal({
         objectId: {type: 4, instance: 630},
-        property: {propertyIdentifier: 85, propertyArrayIndex: 2}
+        property: {id: 85, index: 2}
       });
     });
   });
@@ -1283,8 +1283,8 @@ describe('bacstack - Services layer', function() {
         objectId: {type: 61, instance: 35},
         position: 10,
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 85
+          index: 0xFFFFFFFF,
+          id: 85
         },
         requestType: 1,
         time: undefined
@@ -1301,8 +1301,8 @@ describe('bacstack - Services layer', function() {
         objectId: {type: 61, instance: 35},
         position: 10,
         property: {
-          propertyArrayIndex: 2,
-          propertyIdentifier: 12
+          index: 2,
+          id: 12
         },
         requestType: 1,
         time: undefined
@@ -1319,8 +1319,8 @@ describe('bacstack - Services layer', function() {
         objectId: {type: 61, instance: 35},
         position: 11,
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 85
+          index: 0xFFFFFFFF,
+          id: 85
         },
         requestType: 2,
         time: undefined
@@ -1339,8 +1339,8 @@ describe('bacstack - Services layer', function() {
         objectId: {type: 61, instance: 35},
         position: undefined,
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 85
+          index: 0xFFFFFFFF,
+          id: 85
         },
         requestType: 4,
         time: date
@@ -1354,9 +1354,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 60, instance: 12},
-        eventObjectIdentifier: {type: 61, instance: 1121},
+        processId: 3,
+        initiatingObjectId: {type: 60, instance: 12},
+        eventObjectId: {type: 61, instance: 1121},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1372,9 +1372,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 60, instance: 12},
-        eventObjectIdentifier: {type: 61, instance: 1121},
+        processId: 3,
+        initiatingObjectId: {type: 60, instance: 12},
+        eventObjectId: {type: 61, instance: 1121},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1392,9 +1392,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1410,9 +1410,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1430,9 +1430,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1446,9 +1446,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1466,9 +1466,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1486,9 +1486,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1506,9 +1506,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1523,9 +1523,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1543,9 +1543,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1560,9 +1560,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1580,9 +1580,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1590,8 +1590,8 @@ describe('bacstack - Services layer', function() {
         messageText: 'Test1234$',
         notifyType: 1,
         bufferReadyBufferProperty: {
-          objectIdentifier: {type: 65, instance: 2},
-          propertyIdentifier: 85,
+          objectId: {type: 65, instance: 2},
+          id: 85,
           arrayIndex: 3,
           deviceIndentifier: {type: 8, instance: 443}
         },
@@ -1601,9 +1601,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1621,9 +1621,9 @@ describe('bacstack - Services layer', function() {
       var date = new Date();
       date.setMilliseconds(880);
       baServices.encodeEventNotifyData(buffer, {
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {},
-        eventObjectIdentifier: {},
+        processId: 3,
+        initiatingObjectId: {},
+        eventObjectId: {},
         timeStamp: {type: 2, value: date},
         notificationClass: 9,
         priority: 7,
@@ -1637,9 +1637,9 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeEventNotifyData(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        processIdentifier: 3,
-        initiatingObjectIdentifier: {type: 0, instance: 0},
-        eventObjectIdentifier: {type: 0, instance: 0},
+        processId: 3,
+        initiatingObjectId: {type: 0, instance: 0},
+        eventObjectId: {type: 0, instance: 0},
         timeStamp: date,
         notificationClass: 9,
         priority: 7,
@@ -1665,8 +1665,8 @@ describe('bacstack - Services layer', function() {
         objectId: {type: 61, instance: 35},
         position: 10,
         property: {
-          propertyArrayIndex: 0xFFFFFFFF,
-          propertyIdentifier: 85
+          index: 0xFFFFFFFF,
+          id: 85
         },
         requestType: 1,
         time: undefined
@@ -1694,7 +1694,7 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeCreateObject(buffer, {type: 1, instance: 10}, [
-        {property: {propertyIdentifier: 81, propertyArrayIndex: 0xFFFFFFFF}, value: [
+        {property: {id: 81, index: 0xFFFFFFFF}, value: [
           {type: 0},
           {type: 1, value: null},
           {type: 1, value: true},
@@ -1717,7 +1717,7 @@ describe('bacstack - Services layer', function() {
           {type: 10, value: date},
           {type: 11, value: time}
         ], priority: 0},
-        {property: {propertyIdentifier: 82, propertyArrayIndex: 0}, value: [
+        {property: {id: 82, index: 0}, value: [
           {type: 12, value: {type: 3, instance: 0}}
         ], priority: 0}
       ]);
@@ -1732,40 +1732,40 @@ describe('bacstack - Services layer', function() {
         values: [
           {
             property: {
-              arrayIndex: 0xFFFFFFFF,
-              propertyId: 81
+              index: 0xFFFFFFFF,
+              id: 81
             },
             value: [
-              {type: 0, value: null, len: 1},
-              {type: 0, value: null, len: 1},
-              {type: 1, value: true, len: 1},
-              {type: 1, value: false, len: 1},
-              {type: 2, value: 1, len: 2},
-              {type: 2, value: 1000, len: 3},
-              {type: 2, value: 1000000, len: 4},
-              {type: 2, value: 1000000000, len: 5},
-              {type: 3, value: -1, len: 2},
-              {type: 3, value: -1000, len: 3},
-              {type: 3, value: -1000000, len: 4},
-              {type: 3, value: -1000000000, len: 5},
-              {type: 4, value: 0.1, len: 5},
-              {type: 5, value: 100.121212, len: 10},
-              {type: 6, value: [1, 2, 100, 200], len: 5},
-              {type: 7, value: 'Test1234$', encoding: 0, len: 12},
-              {type: 8, value: {bitsUsed: 0, value: []}, len: 2},
-              {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}, len: 5},
-              {type: 9, value: 4, len: 2},
-              {type: 10, value: date, len: 5},
-              {type: 11, value: time, len: 5}
+              {type: 0, value: null},
+              {type: 0, value: null},
+              {type: 1, value: true},
+              {type: 1, value: false},
+              {type: 2, value: 1},
+              {type: 2, value: 1000},
+              {type: 2, value: 1000000},
+              {type: 2, value: 1000000000},
+              {type: 3, value: -1},
+              {type: 3, value: -1000},
+              {type: 3, value: -1000000},
+              {type: 3, value: -1000000000},
+              {type: 4, value: 0.1},
+              {type: 5, value: 100.121212},
+              {type: 6, value: [1, 2, 100, 200]},
+              {type: 7, value: 'Test1234$', encoding: 0},
+              {type: 8, value: {bitsUsed: 0, value: []}},
+              {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}},
+              {type: 9, value: 4},
+              {type: 10, value: date},
+              {type: 11, value: time}
             ]
           },
           {
             property: {
-              arrayIndex: 0xFFFFFFFF,
-              propertyId: 82
+              index: 0xFFFFFFFF,
+              id: 82
             },
             value: [
-              {type: 12, value: {type: 3, instance: 0}, len: 5}
+              {type: 12, value: {type: 3, instance: 0}}
             ]
           }
         ]
@@ -1780,7 +1780,7 @@ describe('bacstack - Services layer', function() {
       var time = new Date(1, 1, 1);
       time.setMilliseconds(990);
       baServices.encodeCOVNotify(buffer, 7, 443, {type: 2, instance: 12}, 120, [
-        {property: {propertyIdentifier: 81, propertyArrayIndex: 0xFFFFFFFF}, value: [
+        {property: {id: 81, index: 0xFFFFFFFF}, value: [
           {type: 0},
           {type: 1, value: null},
           {type: 1, value: true},
@@ -1803,7 +1803,7 @@ describe('bacstack - Services layer', function() {
           {type: 10, value: date},
           {type: 11, value: time}
         ], priority: 0},
-        {property: {propertyIdentifier: 82, propertyArrayIndex: 0}, value: [
+        {property: {id: 82, index: 0}, value: [
           {type: 12, value: {type: 3, instance: 0}}
         ], priority: 8}
       ]);
@@ -1811,55 +1811,55 @@ describe('bacstack - Services layer', function() {
       delete result.len;
       result.values[0].value[12].value = Math.floor(result.values[0].value[12].value * 1000) / 1000;
       expect(result).to.deep.equal({
-        initiatingDeviceIdentifier: {
+        initiatingDeviceId: {
           type: 8,
           instance: 443
         },
-        monitoredObjectIdentifier: {
+        monitoredObjectId: {
           type: 2,
           instance: 12
         },
-        subscriberProcessIdentifier: 7,
+        subscriberProcessId: 7,
         timeRemaining: 120,
         values: [
           {
             priority: 0,
             property: {
-              arrayIndex: 0xFFFFFFFF,
-              propertyId: 81
+              index: 0xFFFFFFFF,
+              id: 81
             },
             value: [
-              {type: 0, value: null, len: 1},
-              {type: 0, value: null, len: 1},
-              {type: 1, value: true, len: 1},
-              {type: 1, value: false, len: 1},
-              {type: 2, value: 1, len: 2},
-              {type: 2, value: 1000, len: 3},
-              {type: 2, value: 1000000, len: 4},
-              {type: 2, value: 1000000000, len: 5},
-              {type: 3, value: -1, len: 2},
-              {type: 3, value: -1000, len: 3},
-              {type: 3, value: -1000000, len: 4},
-              {type: 3, value: -1000000000, len: 5},
-              {type: 4, value: 0.1, len: 5},
-              {type: 5, value: 100.121212, len: 10},
-              {type: 6, value: [1, 2, 100, 200], len: 5},
-              {type: 7, value: 'Test1234$', encoding: 0, len: 12},
-              {type: 8, value: {bitsUsed: 0, value: []}, len: 2},
-              {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}, len: 5},
-              {type: 9, value: 4, len: 2},
-              {type: 10, value: date, len: 5},
-              {type: 11, value: time, len: 5}
+              {type: 0, value: null},
+              {type: 0, value: null},
+              {type: 1, value: true},
+              {type: 1, value: false},
+              {type: 2, value: 1},
+              {type: 2, value: 1000},
+              {type: 2, value: 1000000},
+              {type: 2, value: 1000000000},
+              {type: 3, value: -1},
+              {type: 3, value: -1000},
+              {type: 3, value: -1000000},
+              {type: 3, value: -1000000000},
+              {type: 4, value: 0.1},
+              {type: 5, value: 100.121212},
+              {type: 6, value: [1, 2, 100, 200]},
+              {type: 7, value: 'Test1234$', encoding: 0},
+              {type: 8, value: {bitsUsed: 0, value: []}},
+              {type: 8, value: {bitsUsed: 24, value: [0xAA, 0xAA, 0xAA]}},
+              {type: 9, value: 4},
+              {type: 10, value: date},
+              {type: 11, value: time}
             ]
           },
           {
             priority: 0,
             property: {
-              arrayIndex: 0xFFFFFFFF,
-              propertyId: 82
+              index: 0xFFFFFFFF,
+              id: 82
             },
             value: [
-              {type: 12, value: {type: 3, instance: 0}, len: 5}
+              {type: 12, value: {type: 3, instance: 0}}
             ]
           }
         ]
@@ -1895,14 +1895,14 @@ describe('bacstack - Services layer', function() {
       var date3 = new Date();
       date3.setMilliseconds(990);
       baServices.encodeEventInformation(buffer, [
-        {objectId: {type: 0, instance: 32}, eventState: 12, ackedTransitions: {value: [14], bitsUsed: 6}, eventTimeStamps: [date1, date2, date3], notifyType: 5, eventEnable: {value: [15], bitsUsed: 7}, eventPriorities: [2, 3, 4]}
+        {objectId: {type: 0, instance: 32}, eventState: 12, acknowledgedTransitions: {value: [14], bitsUsed: 6}, eventTimeStamps: [date1, date2, date3], notifyType: 5, eventEnable: {value: [15], bitsUsed: 7}, eventPriorities: [2, 3, 4]}
       ], false);
       var result = baServices.decodeEventInformation(buffer.buffer, 0, buffer.offset);
       delete result.len;
       expect(result).to.deep.equal({
         alarms: [
           {
-            objectIdentifier: {
+            objectId: {
               type: 0,
               instance: 32
             },
@@ -1940,15 +1940,15 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeAlarmAcknowledge(buffer.buffer, 0, buffer.offset);
       delete result.len;
       expect(result).to.deep.equal({
-        ackProcessIdentifier: 57,
-        eventObjectIdentifier: {
+        acknowledgedProcessId: 57,
+        eventObjectId: {
           type: 0,
           instance: 33
         },
-        eventStateAcked: 5,
-        ackSource: 'Alarm Acknowledge Test',
+        eventStateAcknowledged: 5,
+        acknowledgeSource: 'Alarm Acknowledge Test',
         eventTimeStamp: eventTime,
-        ackTimeStamp: ackTime
+        acknowledgeTimeStamp: ackTime
       });
     });
 
@@ -1960,15 +1960,15 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeAlarmAcknowledge(buffer.buffer, 0, buffer.offset);
       delete result.len;
       expect(result).to.deep.equal({
-        ackProcessIdentifier: 57,
-        eventObjectIdentifier: {
+        acknowledgedProcessId: 57,
+        eventObjectId: {
           type: 0,
           instance: 33
         },
-        eventStateAcked: 5,
-        ackSource: 'Alarm Acknowledge Test',
+        eventStateAcknowledged: 5,
+        acknowledgeSource: 'Alarm Acknowledge Test',
         eventTimeStamp: eventTime,
-        ackTimeStamp: ackTime
+        acknowledgeTimeStamp: ackTime
       });
     });
 
@@ -1982,15 +1982,15 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeAlarmAcknowledge(buffer.buffer, 0, buffer.offset);
       delete result.len;
       expect(result).to.deep.equal({
-        ackProcessIdentifier: 57,
-        eventObjectIdentifier: {
+        acknowledgedProcessId: 57,
+        eventObjectId: {
           type: 0,
           instance: 33
         },
-        eventStateAcked: 5,
-        ackSource: 'Alarm Acknowledge Test',
+        eventStateAcknowledged: 5,
+        acknowledgeSource: 'Alarm Acknowledge Test',
         eventTimeStamp: eventTime,
-        ackTimeStamp: ackTime
+        acknowledgeTimeStamp: ackTime
       });
     });
   });
@@ -2002,7 +2002,7 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodePrivateTransfer(buffer.buffer, 0, buffer.offset);
       delete result.len;
       expect(result).to.deep.equal({
-        vendorID: 255,
+        vendorId: 255,
         serviceNumber: 8,
         data: [1, 2, 3, 4, 5]
       });
@@ -2016,7 +2016,7 @@ describe('bacstack - Services layer', function() {
       var result = baServices.decodeGetEventInformation(buffer.buffer, 0);
       delete result.len;
       expect(result).to.deep.equal({
-        lastReceivedObjectIdentifier: {type: 8, instance: 15}
+        lastReceivedObjectId: {type: 8, instance: 15}
       });
     });
   });
@@ -2043,9 +2043,9 @@ describe('bacstack - Services layer', function() {
       delete result.len;
       expect(result).to.deep.equal({
         processId: 8,
-        requestingSrc: 'User01',
+        requestingSource: 'User01',
         operation: 7,
-        targetObject: {type: 0, instance: 77}
+        targetObjectId: {type: 0, instance: 77}
       });
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: `objId` renamed to `objectId`
BREAKING CHANGE: `objName` renamed to `objectName`
BREAKING CHANGE: `propertyIdentifier` renamed to `propertyId`
BREAKING CHANGE: `propertyArrayIndex` renamed to `index`
BREAKING CHANGE: `valueList` renamed to `values`
BREAKING CHANGE: `objectIdentifier` renamed to `objectId`
BREAKING CHANGE: `propertyReferences` renamed to `properties`
BREAKING CHANGE: `Recipient.net` renamed to `recipient.network`
BREAKING CHANGE: `Recipient.adr` renamed to `recipient.address`
BREAKING CHANGE: `subscriptionProcessId` renamed to `subscriptionProcessIdentifier`
BREAKING CHANGE: `objectIdentifier` renamed to `objectId`
BREAKING CHANGE: drop of `len` parameter for properties