### PR TITLE
refactor(bacnet-client): split-up UTC and default time-sync

### DIFF
--- a/lib/bacnet-client.js
+++ b/lib/bacnet-client.js
@@ -402,22 +402,37 @@ module.exports = function(options) {
    * @function bacstack.timeSync
    * @param {string} address - IP address of the target device.
    * @param {date} dateTime - The date and time to set on the target device.
-   * @param {boolean} [isUtc=false] - Identifier if UTC time sync service shall be used.
    * @example
    * var bacnet = require('bacstack');
    * var client = new bacnet();
    *
-   * client.timeSync('192.168.1.43', new Date(), true);
+   * client.timeSync('192.168.1.43', new Date());
    */
-  // TODO: Split up in UTC and non-utc
   self.timeSync = function(address, dateTime, isUtc) {
     var buffer = getBuffer();
     baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE, address);
-    if (!isUtc) {
-      baAdpu.encodeUnconfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION);
-    } else {
-      baAdpu.encodeUnconfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION);
-    }
+    baAdpu.encodeUnconfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION);
+    baServices.encodeTimeSync(buffer, dateTime);
+    var npduType = (address !== transport.getBroadcastAddress()) ? baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU : baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_BROADCAST_NPDU;
+    baBvlc.encode(buffer.buffer, npduType, buffer.offset);
+    transport.send(buffer.buffer, buffer.offset, address);
+  };
+
+  /**
+   * The timeSyncUTC command sets the UTC time of a target device.
+   * @function bacstack.timeSyncUTC
+   * @param {string} address - IP address of the target device.
+   * @param {date} dateTime - The date and time to set on the target device.
+   * @example
+   * var bacnet = require('bacstack');
+   * var client = new bacnet();
+   *
+   * client.timeSyncUTC('192.168.1.43', new Date());
+   */
+  self.timeSyncUTC = function(address, dateTime, isUtc) {
+    var buffer = getBuffer();
+    baNpdu.encode(buffer, baEnum.BacnetNpduControls.PRIORITY_NORMAL_MESSAGE, address);
+    baAdpu.encodeUnconfirmedServiceRequest(buffer, baEnum.BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, baEnum.BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION);
     baServices.encodeTimeSync(buffer, dateTime);
     var npduType = (address !== transport.getBroadcastAddress()) ? baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU : baEnum.BacnetBvlcFunctions.BVLC_ORIGINAL_BROADCAST_NPDU;
     baBvlc.encode(buffer.buffer, npduType, buffer.offset);

--- a/test/integration/time-sync-utc.spec.js
+++ b/test/integration/time-sync-utc.spec.js
@@ -1,0 +1,10 @@
+var expect = require('chai').expect;
+var utils = require('./utils');
+
+describe('bacstack - timeSyncUTC integration', function() {
+  it('should send a time UTC sync package', function() {
+    var client = new utils.bacnetClient({adpuTimeout: 200});
+    client.timeSyncUTC('127.0.0.1', new Date());
+    client.close();
+  });
+});

--- a/test/integration/time-sync.spec.js
+++ b/test/integration/time-sync.spec.js
@@ -4,13 +4,7 @@ var utils = require('./utils');
 describe('bacstack - timeSync integration', function() {
   it('should send a time sync package', function() {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.timeSync('127.0.0.1', new Date(), false);
-    client.close();
-  });
-
-  it('should send a time UTC sync package', function() {
-    var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.timeSync('127.0.0.1', new Date(), true);
+    client.timeSync('127.0.0.1', new Date());
     client.close();
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: `isUTC` parameter has been omitted and was replaced by the `timeSyncUTC` function