### PR TITLE
refactor(client): combine object type and instance parameter to `obejctId`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -449,8 +449,9 @@ module.exports = function(options) {
    * The readProperty command reads a single property of an object from a device.
    * @function bacstack.readProperty
    * @param {string} address - IP address of the target device.
-   * @param {number} objectType - The BACNET object type to read.
-   * @param {number} objectInstance - The BACNET object instance to read.
+   * @param {object} objectId - The BACNET object ID to read.
+   * @param {number} objectId.type - The BACNET object type to read.
+   * @param {number} objectId.instance - The BACNET object instance to read.
    * @param {number} propertyId - The BACNET property id in the specified object to read.
    * @param {object=} options
    * @param {MaxSegments=} options.maxSegments - The maximimal allowed number of segments.
@@ -462,11 +463,11 @@ module.exports = function(options) {
    * var bacnet = require('bacstack');
    * var client = new bacnet();
    *
-   * client.readProperty('192.168.1.43', 8, 44301, 28, function(err, value) {
+   * client.readProperty('192.168.1.43', {type: 8, instance: 44301}, 28, function(err, value) {
    *   console.log('value: ', value);
    * });
    */
-  self.readProperty = function(address, objectType, objectInstance, propertyId, options, next) {
+  self.readProperty = function(address, objectId, propertyId, options, next) {
     next = next || options;
     var settings = {
       maxSegments: options.maxSegments || baEnum.MaxSegments.MAX_SEG65,
@@ -478,7 +479,7 @@ module.exports = function(options) {
     baNpdu.encode(buffer, baEnum.NpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.NpduControls.EXPECTING_REPLY, address, null, DEFAULT_HOP_COUNT, baEnum.NetworkMessageTypes.NETWORK_MESSAGE_WHO_IS_ROUTER_TO_NETWORK, 0);
     var type = baEnum.PduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST | (settings.maxSegments !== baEnum.MaxSegments.MAX_SEG0 ? baEnum.PduTypes.SEGMENTED_RESPONSE_ACCEPTED : 0);
     baAdpu.encodeConfirmedServiceRequest(buffer, type, baEnum.ConfirmedServices.SERVICE_CONFIRMED_READ_PROPERTY, settings.maxSegments, settings.maxAdpu, settings.invokeId, 0, 0);
-    baServices.encodeReadProperty(buffer, objectType, objectInstance, propertyId, settings.arrayIndex);
+    baServices.encodeReadProperty(buffer, objectId.type, objectId.instance, propertyId, settings.arrayIndex);
     baBvlc.encode(buffer.buffer, baEnum.BvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(settings.invokeId, function(err, data) {
@@ -493,10 +494,10 @@ module.exports = function(options) {
    * The writeProperty command writes a single property of an object to a device.
    * @function bacstack.writeProperty
    * @param {string} address - IP address of the target device.
-   * @param {number} objectType - The BACNET object type to write.
-   * @param {number} objectInstance - The BACNET object instance to write.
+   * @param {object} objectId - The BACNET object ID to write.
+   * @param {number} objectId.type - The BACNET object type to write.
+   * @param {number} objectId.instance - The BACNET object instance to write.
    * @param {number} propertyId - The BACNET property id in the specified object to write.
-   * @param {number} priority - The priority to be used for writing to the property.
    * @param {object[]} values - A list of values to be written to the specified property.
    * @param {ApplicationTags} values.tag - The data-type of the value to be written.
    * @param {number} values.value - The actual value to be written.
@@ -511,13 +512,13 @@ module.exports = function(options) {
    * var bacnet = require('bacstack');
    * var client = new bacnet();
    *
-   * client.writeProperty('192.168.1.43', 8, 44301, 28, 12, [
+   * client.writeProperty('192.168.1.43', {type: 8, instance: 44301}, 28, [
    *   {type: bacnet.enum.ApplicationTags.BACNET_APPLICATION_TAG_REAL, value: 100}
    * ], function(err, value) {
    *   console.log('value: ', value);
    * });
    */
-  self.writeProperty = function(address, objectType, objectInstance, propertyId, values, options, next) {
+  self.writeProperty = function(address, objectId, propertyId, values, options, next) {
     next = next || options;
     var settings = {
       maxSegments: options.maxSegments || baEnum.MaxSegments.MAX_SEG65,
@@ -529,7 +530,7 @@ module.exports = function(options) {
     var buffer = getBuffer();
     baNpdu.encode(buffer, baEnum.NpduControls.PRIORITY_NORMAL_MESSAGE | baEnum.NpduControls.EXPECTING_REPLY, address, null, DEFAULT_HOP_COUNT, baEnum.NetworkMessageTypes.NETWORK_MESSAGE_WHO_IS_ROUTER_TO_NETWORK, 0);
     baAdpu.encodeConfirmedServiceRequest(buffer, baEnum.PduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, baEnum.ConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY, settings.maxSegments, settings.maxAdpu, settings.invokeId, 0, 0);
-    baServices.encodeWriteProperty(buffer, objectType, objectInstance, propertyId, settings.arrayIndex, settings.priority, values);
+    baServices.encodeWriteProperty(buffer, objectId.type, objectId.instance, propertyId, settings.arrayIndex, settings.priority, values);
     baBvlc.encode(buffer.buffer, baEnum.BvlcFunctions.BVLC_ORIGINAL_UNICAST_NPDU, buffer.offset);
     transport.send(buffer.buffer, buffer.offset, address);
     addCallback(settings.invokeId, function(err, data) {

--- a/test/integration/read-property.spec.js
+++ b/test/integration/read-property.spec.js
@@ -4,7 +4,7 @@ var utils = require('./utils');
 describe('bacstack - readProperty integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.readProperty('127.0.0.1', 8, 44301, 28, function(err, value) {
+    client.readProperty('127.0.0.1', {type: 8, instance: 44301}, 28, function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');
       expect(value).to.eql(undefined);
       client.close();

--- a/test/integration/write-property.spec.js
+++ b/test/integration/write-property.spec.js
@@ -4,7 +4,7 @@ var utils = require('./utils');
 describe('bacstack - writeProperty integration', function() {
   it('should return a timeout error if no device is available', function(next) {
     var client = new utils.bacnetClient({adpuTimeout: 200});
-    client.writeProperty('127.0.0.1', 8, 44301, 28, [{type: 4, value: 100}], function(err, value) {
+    client.writeProperty('127.0.0.1', {type: 8, instance: 44301}, 28, [{type: 4, value: 100}], function(err, value) {
       expect(err.message).to.eql('ERR_TIMEOUT');
       expect(value).to.eql(undefined);
       client.close();


### PR DESCRIPTION
BREAKING CHANGE: `objectType` and `objectInstance` parameters for all functions have been replaced by a single `obejctId` parameter, expecting an object with `type` and `instance` attribute.