### PR TITLE
WIP: Chore/license compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 script:
   - "commitlint-travis"
   - "npm run lint"
+  - "npm run repolinter"
   - "npm run test"
   - "cat ./reports/coverage/lcov.info | ./node_modules/.bin/coveralls"
   - "npm run integration"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 fh1ch
+Copyright (c) 2017 Fabio Huser <fabio@fh1.ch>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "jshint lib/ test/ index.js && jscs lib/ test/ index.js",
     "test": "istanbul cover --dir reports/coverage node_modules/mocha/bin/_mocha -- test/unit/*.spec.js",
     "integration": "istanbul cover --dir reports/coverage node_modules/mocha/bin/_mocha -- test/integration/*.spec.js",
-    "docs": "jsdoc -d ./docs -t node_modules/docdash ./lib ./index.js ./README.md"
+    "docs": "jsdoc -d ./docs -t node_modules/docdash ./lib ./index.js ./README.md",
+    "repolinter": "repolinter ."
   },
   "repository": {
     "type": "git",
@@ -39,7 +40,8 @@
   "homepage": "https://github.com/fh1ch/node-bacstack#readme",
   "dependencies": {
     "debug": "^3.1.0",
-    "iconv-lite": "^0.4.19"
+    "iconv-lite": "^0.4.19",
+    "repolinter": "bufferoverflow/repolinter#fix/reuse-software"
   },
   "devDependencies": {
     "@commitlint/cli": "^5.2.5",

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,3 +1,5 @@
+// Copyright (C) 2017 Fabio Huser <fabio@fh1.ch>
+// SPDX-License-Identifier: MIT
 module.exports.getBuffer = function() {
   return {
     buffer: Buffer.alloc(1482),


### PR DESCRIPTION
This is related to #83 , it adds repolinter (from my branch until https://github.com/todogroup/repolinter/pull/63 is merged) and the license header as suggested by reuse.software. I will add all those headers if you @fh1ch agree on this.