### PR TITLE
[WIP] docs(readme): add Headerless.org badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ interact with building automation devices defined by ASHRAE.
 [![](https://coveralls.io/repos/fh1ch/node-bacstack/badge.svg?branch=master)](https://coveralls.io/r/fh1ch/node-bacstack?branch=master)
 [![](https://codeclimate.com/github/fh1ch/node-bacstack/badges/gpa.svg)](https://codeclimate.com/github/fh1ch/node-bacstack)
 [![](https://david-dm.org/fh1ch/node-bacstack/status.svg)](https://david-dm.org/fh1ch/node-bacstack)
+[![](https://img.shields.io/badge/HEADER-LESS-brightgreen.svg)](http://headerless.org)
 
 > **Note:** This is an early prototype and shall not be considered as stable.
 > Use it with caution and at your own risk!


### PR DESCRIPTION
Headerless.org promotes a simplified copyright and license handling, which Node BACstack already complies with. Therefore, a badge is added to visualise this fact.