### PR TITLE
Support for BBMD messages and COV pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ following services are already supported at this point in time:
 | Create Object                  | yes¹                                                                                   | yes¹                                                                          |
 | Delete Object                  | yes¹                                                                                   | yes¹                                                                          |
 | Subscribe COV                  | yes¹                                                                                   | yes¹                                                                          |
+| Confirmed COV Notification     | yes¹                                                                                   | yes¹                                                                          |
 | Subscribe Property             | yes¹                                                                                   | yes¹                                                                          |
 | Atomic Read File               | yes¹                                                                                   | yes¹                                                                          |
 | Atomic Write File              | yes¹                                                                                   | yes¹                                                                          |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ following services are already supported at this point in time:
 | Unconfirmed Private Transfer   | yes¹                                                                                   | yes¹                                                                          |
 | Confirmed Private Transfer     | yes¹                                                                                   | yes¹                                                                          |
 | Register Foreign Device        | no                                                                                     | yes¹                                                                          |
+| Distribute Broadcast to Network| no                                                                                     | yes¹                                                                          |
 
 ¹ Support implemented as Beta (untested, undocumented, breaking interface)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ following services are already supported at this point in time:
 | Unconfirmed Event Notification | yes¹                                                                                   | yes¹                                                                          |
 | Unconfirmed Private Transfer   | yes¹                                                                                   | yes¹                                                                          |
 | Confirmed Private Transfer     | yes¹                                                                                   | yes¹                                                                          |
+| Register Foreign Device        | no                                                                                     | yes¹                                                                          |
 
 ¹ Support implemented as Beta (untested, undocumented, breaking interface)
 

--- a/lib/apdu.js
+++ b/lib/apdu.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const baAsn1      = require('./asn1');
 const baEnum      = require('./enum');
 
 const getDecodedType = module.exports.getDecodedType = (buffer, offset) => {
@@ -150,6 +151,20 @@ module.exports.decodeSegmentAck = (buffer, offset) => {
     originalInvokeId: originalInvokeId,
     sequencenumber: sequencenumber,
     actualWindowSize: actualWindowSize
+  };
+};
+
+module.exports.encodeResult = (buffer, /* BvlcResultFormat */ resultCode) => {
+  baAsn1.encodeUnsigned(buffer, resultCode, 2);
+};
+
+module.exports.decodeResult = (buffer, offset) => {
+  const orgOffset = offset;
+  const decode = baAsn1.decodeUnsigned(buffer, offset, 2);
+  offset += decode.len;
+  return {
+    len: offset - orgOffset,
+    resultCode: decode.value, // BvlcResultFormat
   };
 };
 

--- a/lib/asn1.js
+++ b/lib/asn1.js
@@ -46,7 +46,7 @@ const getEncodingType = (encoding, decodingBuffer, decodingOffset) => {
   }
 };
 
-const encodeUnsigned = (buffer, value, length) => {
+const encodeUnsigned = module.exports.encodeUnsigned = (buffer, value, length) => {
   buffer.buffer.writeUIntBE(value, buffer.offset, length, true);
   buffer.offset += length;
 };

--- a/lib/bvlc.js
+++ b/lib/bvlc.js
@@ -20,11 +20,6 @@ module.exports.decode = (buffer, offset) => {
     case baEnum.BvlcResultPurpose.ORIGINAL_UNICAST_NPDU:
     case baEnum.BvlcResultPurpose.ORIGINAL_BROADCAST_NPDU:
     case baEnum.BvlcResultPurpose.DISTRIBUTE_BROADCAST_TO_NETWORK:
-      len =  4;
-      break;
-    case baEnum.BvlcResultPurpose.FORWARDED_NPDU:
-      len = 10;
-      break;
     case baEnum.BvlcResultPurpose.REGISTER_FOREIGN_DEVICE:
     case baEnum.BvlcResultPurpose.READ_FOREIGN_DEVICE_TABLE:
     case baEnum.BvlcResultPurpose.DELETE_FOREIGN_DEVICE_TABLE_ENTRY:
@@ -32,7 +27,13 @@ module.exports.decode = (buffer, offset) => {
     case baEnum.BvlcResultPurpose.WRITE_BROADCAST_DISTRIBUTION_TABLE:
     case baEnum.BvlcResultPurpose.READ_BROADCAST_DISTRIBUTION_TABLE_ACK:
     case baEnum.BvlcResultPurpose.READ_FOREIGN_DEVICE_TABLE_ACK:
+      len = 4;
+      break;
+    case baEnum.BvlcResultPurpose.FORWARDED_NPDU:
+      len = 10;
+      break;
     case baEnum.BvlcResultPurpose.SECURE_BVLL:
+      // unimplemented
       return;
     default:
       return;

--- a/lib/client.js
+++ b/lib/client.js
@@ -444,10 +444,20 @@ class Client extends EventEmitter {
     const result = baBvlc.decode(buffer, 0);
     if (!result) return debug('Received invalid BVLC header -> Drop package');
     // Check BVLC function
-    if (result.func === baEnum.BvlcResultPurpose.ORIGINAL_UNICAST_NPDU || result.func === baEnum.BvlcResultPurpose.ORIGINAL_BROADCAST_NPDU || result.func === baEnum.BvlcResultPurpose.FORWARDED_NPDU) {
-      this._handleNpdu(buffer, result.len, buffer.length - result.len, remoteAddress);
-    } else {
-      debug('Received unknown BVLC function -> Drop package');
+    switch (result.func) {
+      case baEnum.BvlcResultPurpose.ORIGINAL_UNICAST_NPDU:
+      case baEnum.BvlcResultPurpose.ORIGINAL_BROADCAST_NPDU:
+      case baEnum.BvlcResultPurpose.FORWARDED_NPDU:
+        this._handleNpdu(buffer, result.len, buffer.length - result.len, remoteAddress);
+        break;
+      case baEnum.BvlcResultPurpose.REGISTER_FOREIGN_DEVICE:
+        let decodeResult = baServices.registerForeignDevice.decode(buffer, result.len, buffer.length - result.len);
+        if (!decodeResult) return debug('Received invalid registerForeignDevice message');
+        this.emit('registerForeignDevice', {address: remoteAddress, request: decodeResult});
+        break;
+      default:
+        debug('Received unknown BVLC function -> Drop package');
+        break;
     }
   }
 
@@ -1166,6 +1176,13 @@ class Client extends EventEmitter {
     baNpdu.encode(buffer, baEnum.NpduControlPriority.NORMAL_MESSAGE, receiver);
     baApdu.encodeSimpleAck(buffer, baEnum.PduTypes.SIMPLE_ACK, service, invokeId);
     baBvlc.encode(buffer.buffer, baEnum.BvlcResultPurpose.ORIGINAL_UNICAST_NPDU, buffer.offset);
+    this._transport.send(buffer.buffer, buffer.offset, receiver);
+  }
+
+  resultResponse(receiver, resultCode) {
+    const buffer = this._getBuffer();
+    baApdu.encodeResult(buffer, resultCode);
+    baBvlc.encode(buffer.buffer, baEnum.BvlcResultPurpose.BVLC_RESULT, buffer.offset);
     this._transport.send(buffer.buffer, buffer.offset, receiver);
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -747,6 +747,71 @@ class Client extends EventEmitter {
   }
 
   /**
+   * The confirmedCOVNotification command is used to push notifications to other
+   * systems that have registered with us via a subscribeCOV message.
+   * @function bacstack.confirmedCOVNotification
+   * @param {string} address - IP address of the target device.
+   * @param {object} monitoredObject - The object being monitored, from subscribeCOV.
+   * @param {number} monitoredObject.type - Object type.
+   * @param {number} monitoredObject.instance - Object instance.
+   * @param {number} subscribeId - Subscriber ID from subscribeCOV,
+   * @param {number} initiatingDeviceId - Our BACnet device ID.
+   * @param {number} lifetime - Number of seconds left until the subscription expires.
+   * @param {array} values - values for the monitored object.  See example.
+   * @param {object=} options
+   * @param {MaxSegmentsAccepted=} options.maxSegments - The maximimal allowed number of segments.
+   * @param {MaxApduLengthAccepted=} options.maxApdu - The maximal allowed APDU size.
+   * @param {number=} options.invokeId - The invoke ID of the confirmed service telegram.
+   * @param {function} next - The callback containing an error, in case of a failure and value object in case of success.
+   * @example
+   * const bacnet = require('bacstack');
+   * const client = new bacnet();
+   *
+   * const settings = {deviceId: 123}; // our BACnet device
+   *
+   * // Items saved from subscribeCOV message
+   * const monitoredObject = {type: 1, instance: 1};
+   * const subscriberProcessId = 123;
+   *
+   * client.confirmedCOVNotification(
+   *   '192.168.1.43',
+   *   monitoredObject,
+   *   subscriberProcessId,
+   *   settings.deviceId,
+   *   30, // should be lifetime of subscription really
+   *   [
+   *     {
+   *       property: { id: bacnet.enum.PropertyIdentifier.PRESENT_VALUE },
+   *       value: [
+   *         {value: 123, type: bacnet.enum.ApplicationTags.REAL},
+   *       ],
+   *     },
+   *   ],
+   *   (err) => {
+   *     console.log('error: ', err);
+   *   }
+   * );
+   */
+  confirmedCOVNotification(address, monitoredObject, subscribeId, initiatingDeviceId, lifetime, values, options, next) {
+    next = next || options;
+    const settings = {
+      maxSegments: options.maxSegments || baEnum.MaxSegmentsAccepted.SEGMENTS_65,
+      maxApdu: options.maxApdu || baEnum.MaxApduLengthAccepted.OCTETS_1476,
+      invokeId: options.invokeId || this._getInvokeId()
+    };
+    const buffer = this._getBuffer();
+    baNpdu.encode(buffer, baEnum.NpduControlPriority.NORMAL_MESSAGE | baEnum.NpduControlBits.EXPECTING_REPLY, address);
+    baApdu.encodeConfirmedServiceRequest(buffer, baEnum.PduTypes.CONFIRMED_REQUEST, baEnum.ConfirmedServiceChoice.CONFIRMED_COV_NOTIFICATION, settings.maxSegments, settings.maxApdu, settings.invokeId, 0, 0);
+    baServices.covNotify.encode(buffer, subscribeId, initiatingDeviceId, monitoredObject, lifetime, values);
+    baBvlc.encode(buffer.buffer, baEnum.BvlcResultPurpose.ORIGINAL_UNICAST_NPDU, buffer.offset);
+    this._transport.send(buffer.buffer, buffer.offset, address);
+    this._addCallback(settings.invokeId, (err, data) => {
+      if (err) return next(err);
+      next();
+    });
+  }
+
+  /**
    * The deviceCommunicationControl command enables or disables network communication of the target device.
    * @function bacstack.deviceCommunicationControl
    * @param {string} address - IP address of the target device.

--- a/lib/client.js
+++ b/lib/client.js
@@ -455,8 +455,11 @@ class Client extends EventEmitter {
         if (!decodeResult) return debug('Received invalid registerForeignDevice message');
         this.emit('registerForeignDevice', {address: remoteAddress, request: decodeResult});
         break;
+      case baEnum.BvlcResultPurpose.DISTRIBUTE_BROADCAST_TO_NETWORK:
+        this._handleNpdu(buffer, result.len, buffer.length - result.len, remoteAddress);
+        break;
       default:
-        debug('Received unknown BVLC function -> Drop package');
+        debug('Received unknown BVLC function ' + result.func + ' -> Drop package');
         break;
     }
   }

--- a/lib/services/index.js
+++ b/lib/services/index.js
@@ -22,6 +22,7 @@ module.exports.readPropertyMultiple = require('./read-property-multiple');
 module.exports.readProperty = require('./read-property');
 module.exports.readRange = require('./read-range');
 module.exports.reinitializeDevice = require('./reinitialize-device');
+module.exports.registerForeignDevice = require('./register-foreign-device');
 module.exports.subscribeCov = require('./subscribe-cov');
 module.exports.subscribeProperty = require('./subscribe-property');
 module.exports.timeSync = require('./time-sync');

--- a/lib/services/register-foreign-device.js
+++ b/lib/services/register-foreign-device.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const baAsn1      = require('../asn1');
+
+module.exports.encode = (buffer, ttl) => {
+  baAsn1.encodeUnsigned(buffer, ttl, 2);
+};
+
+module.exports.decode = (buffer, offset, length) => {
+  let len = 0;
+  let result;
+  result = baAsn1.decodeUnsigned(buffer, offset + len, 2);
+  len += result.len;
+  return {
+    len: len,
+    ttl: result.value,
+  };
+};


### PR DESCRIPTION
### Checklist

- [X] I've read and followed the [Contribution Guide](https://github.com/fh1ch/node-bacstack/blob/master/CONTRIBUTING.md).
- [X] My commit messages reference affected issues and mention breaking changes if applicable.
- [X] I've updated / wrote inline documentation for the source code affected by my changes.
- [ ] All mandatory CI checks have passed (see when Pull Request has been submitted).

### What does this Pull Request do

This adds support for a couple of BACnet messages useful when implementing a client device.  It allows the device to appear as a BBMD (sort of a BACnet proxy server), which is useful for some systems (such as Johnson Controls Metasys) which can only talk to BBMD proxies and cannot talk to remote BACnet devices directly.

It also adds the ability to send COV notifications.  A remote BACnet system can already subscribe to a data element provided by a device based on this library, however without this addition there is no way to make use of this subscription to push updates to the remote system as they occur.