### PR TITLE
Support BACnet devices on nonstandard ports

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -3,12 +3,14 @@
 const createSocket      = require('dgram').createSocket;
 const EventEmitter      = require('events').EventEmitter;
 
+const DefaultBACnetPort = 47808;
+
 class Transport extends EventEmitter {
   constructor(settings) {
     super();
     this._settings = settings;
     this._server = createSocket({type: 'udp4', reuseAddr: true});
-    this._server.on('message', (msg, rinfo) => this.emit('message', msg, rinfo.address));
+    this._server.on('message', (msg, rinfo) => this.emit('message', msg, rinfo.address + (rinfo.port === DefaultBACnetPort ? '' : ':' + rinfo.port)));
     this._server.on('error', (err) => this.emit('message', err));
   }
 
@@ -21,7 +23,8 @@ class Transport extends EventEmitter {
   }
 
   send(buffer, offset, receiver) {
-    this._server.send(buffer, 0, offset, this._settings.port, receiver);
+    const [address, port] = receiver.split(':');
+    this._server.send(buffer, 0, offset, port || DefaultBACnetPort, address);
   }
 
   open() {


### PR DESCRIPTION
When communicating with other BACnet devices on the same machine, different ports must be used to ensure communications go to the right instance.

The outgoing messages were being sent on the standard BACnet UDP port, instead of going out to the same port they arrived from, making communications with nonstandard devices impossible.

This small patch includes the port number in the address field if it is nonstandard, fixing the issue.

I have tested this both with listening on port 47809 and talking to a device on port 47809, rather than the usual port 47808.